### PR TITLE
Add templated analysis config and generate at runtime

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -3,7 +3,8 @@ version: "3.8"
 services:
   katago:
     build:
-      context: ./docker
+      context: .
+      dockerfile: docker/Dockerfile
       args:
         KATAGO_VER: ${KATAGO_VER:-v1.16.2}
     image: local/katago:${KATAGO_VER:-v1.16.2}

--- a/configs/analysis.cfg.tmpl
+++ b/configs/analysis.cfg.tmpl
@@ -1,0 +1,8 @@
+# KataGo analysis configuration template. Values may be overridden via environment variables.
+maxVisits = ${KATAGO_VISITS:-150}
+numAnalysisThreads = ${KATAGO_ANALYSIS_THREADS:-8}
+nnMaxBatchSize = ${KATAGO_NN_MAX_BATCH_SIZE:-64}
+nnCacheSizePowerOfTwo = ${KATAGO_NN_CACHE_SIZE_POW2:-23}
+nnMutexPoolSizePowerOfTwo = ${KATAGO_NN_MUTEX_POOL_SIZE_POW2:-16}
+allowSlowEngine = ${KATAGO_ALLOW_SLOW_ENGINE:-true}
+reportAnalysisWinratesAs = "${KATAGO_REPORT_WINRATES_AS:-BLACK}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,8 +17,8 @@ RUN curl -L -o katago.zip \
  && rm katago.zip \
  && chmod +x /opt/katago/katago
 
-# Config + entrypoint
-COPY analysis.cfg /opt/katago/analysis.cfg
+# Config template + entrypoint
+COPY configs/analysis.cfg.tmpl /opt/katago/analysis.cfg.tmpl
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 

--- a/docker/analysis.cfg
+++ b/docker/analysis.cfg
@@ -1,8 +1,0 @@
-# Minimal, safe defaults; tune later.
-# Lower visit count helps KataGo respond quickly on modest GPUs/CPUs.
-maxVisits = 200
-numAnalysisThreads = 8
-nnCacheSizePowerOfTwo = 20
-nnMutexPoolSizePowerOfTwo = 16
-allowSlowEngine = true
-reportAnalysisWinratesAs = "BLACK"   # GUI can flip

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 MODEL="${KATAGO_MODEL:-/models/latest.bin.gz}"
+CFG_TEMPLATE="/opt/katago/analysis.cfg.tmpl"
 CFG="/opt/katago/analysis.cfg"
 PORT="${KATAGO_PORT:-2388}"
 THREADS="${KATAGO_ANALYSIS_THREADS:-8}"
@@ -39,6 +40,16 @@ if ! compgen -G "/dev/nvidia*" >/dev/null 2>&1; then
     exit 1
   fi
 fi
+
+if [ ! -f "$CFG_TEMPLATE" ]; then
+  echo "Config template not found at $CFG_TEMPLATE" >&2
+  exit 1
+fi
+
+CONFIG_CONTENT="$(cat "$CFG_TEMPLATE")"
+eval "cat <<EOF
+$CONFIG_CONTENT
+EOF" > "$CFG"
 
 echo "Starting KataGo analysis @ 0.0.0.0:${PORT} with model $REAL_MODEL"
 


### PR DESCRIPTION
## Summary
- add an analysis config template with environment-driven defaults
- update the Docker image and entrypoint to render the runtime config from the template
- adjust the compose build context so the template is included in the image

## Testing
- bash -n docker/entrypoint.sh

------
https://chatgpt.com/codex/tasks/task_e_68d1ae3b5ca08324a14d7ee235723ee1