### PR TITLE
Add Docker build pipeline for KataGo CUDA binary

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,20 @@
+FROM nvidia/cuda:12.4.1-devel-ubuntu22.04
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git \
+        cmake \
+        g++ \
+        zlib1g-dev \
+        libzip-dev \
+        libzstd-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth 1 --branch v1.16.3 https://github.com/lightvector/KataGo.git /src/katago
+
+RUN cmake -S /src/katago/cpp -B /src/build \
+    -DUSE_BACKEND=CUDA \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CUDA_ARCHITECTURES=86
+
+RUN cmake --build /src/build -j"$(nproc)"

--- a/build_and_extract.sh
+++ b/build_and_extract.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE="katago-build:fix"
+CONTAINER="kb"
+
+rm -f katago
+
+docker build -f Dockerfile.build -t "${IMAGE}" .
+
+docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
+docker create --name "${CONTAINER}" "${IMAGE}"
+
+docker cp "${CONTAINER}:/src/build/katago" ./katago
+
+docker rm "${CONTAINER}"
+
+./katago version


### PR DESCRIPTION
## Summary
- add a minimal Dockerfile to build KataGo v1.16.3 with CUDA backend from upstream
- add a helper script to build the image, extract the katago binary, and verify the version

## Testing
- `./build_and_extract.sh` *(fails: docker not available in CI sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b53adfdc8324a4f91ad3a3f46ff7