### PR TITLE
Fix docker compose config for KataGo service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,18 @@
-+4-7
 version: "3.8"
 
 services:
- image: katago-json:fdf52bf
+  katago:
+    image: katago-json:fdf52bf
     container_name: katago-analysis
     environment:
-      - KATAGO_MODEL=/models/${KATAGO_MODEL_FILE:-latest.bin.gz}
-      - KATAGO_PORT=${KATAGO_PORT:-2388}
-      
-      - KATAGO_ANALYSIS_THREADS=${KATAGO_ANALYSIS_THREADS:-8}
-      - KATAGO_CONFIG=/config/analysis.cfg
-      - NVIDIA_VISIBLE_DEVICES=all
-      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+      KATAGO_MODEL: /models/${KATAGO_MODEL_FILE:-latest.bin.gz}
+      KATAGO_PORT: "${KATAGO_PORT:-2388}"
+      KATAGO_ANALYSIS_THREADS: "${KATAGO_ANALYSIS_THREADS:-8}"
+      KATAGO_VISITS: "${KATAGO_VISITS:-800}"
+      KATAGO_SEARCH_THREADS: "${KATAGO_SEARCH_THREADS:-8}"
+      KATAGO_CONFIG: /config/analysis.cfg
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: compute,utility
     ports:
       - "127.0.0.1:${KATAGO_PORT:-2388}:2388"
     volumes:
@@ -24,4 +25,3 @@ services:
             - driver: nvidia
               count: 1
               capabilities: [gpu]
-


### PR DESCRIPTION
## Summary
- restore a valid docker compose specification for the katago analysis service
- expose the engine on 127.0.0.1 with configurable ports and mount model/config directories read-only
- configure environment defaults and GPU device reservations for the container

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d1b74ff220832493ee74f323d6f46e