### PR TITLE
Enable Docker Compose to build runtime image

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -25,12 +25,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4
 
-      # Runs a single command using the runners shell
-      - name: Run a one-line script
-        run: echo Hello, world!
-
-      # Runs a set of commands using the runners shell
-      - name: Run a multi-line script
+      - name: Docker Compose sanity check
         run: |
-          echo Add other actions to build,
-          echo test, and deploy your project.
+          export IMAGE_TAG=$(git rev-parse --short HEAD)
+          docker compose build --progress plain

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 cd KataGo
 ./scripts/00_setup_dirs.sh
 ./scripts/01_get_model.sh   # follow prompt; keep kata1*.bin.gz name
+export IMAGE_TAG=$(git rev-parse --short HEAD)
 docker compose build --no-cache
 docker compose up -d
 docker compose logs -f katago

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,10 @@ version: "3.8"
 
 services:
   katago:
-    image: katago-json:fdf52bf
+    image: katago-json:${IMAGE_TAG:-dev}
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
     container_name: katago-analysis
     environment:
       KATAGO_MODEL: /models/${KATAGO_MODEL_FILE:-latest.bin.gz}


### PR DESCRIPTION
## Summary
- configure the katago service to build from docker/Dockerfile while retaining the existing image tag
- document exporting IMAGE_TAG in the quickstart instructions
- replace the placeholder CI workflow step with a docker compose build sanity check

## Testing
- not run (docker is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d1bade8f9c832488b749cbbd2fb2c1