### PR TITLE
Allow overriding visits and search threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ export KATAGO_ANALYSIS_THREADS=16
 docker compose up -d
 ```
 
+You can also override `analysis.cfg` values without editing the file by exporting `KATAGO_VISITS` (maps to `maxVisits`) or
+`KATAGO_SEARCH_THREADS` (maps to `numSearchThreadsPerAnalysisThread`). When these environment variables are set to positive integers,
+the entrypoint passes them to `katago analysis` via `-override-config`, taking precedence over the base configuration. Leave them
+unset (or empty) to keep the values defined in `analysis.cfg`.
+
 ## KaTrain configuration
 
 KaTrain connects to KataGo through its JSON analysis engine over a socket. Configure the engine in KaTrain → Settings → Engine:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,9 @@ services:
       KATAGO_MODEL: /models/latest.bin.gz
       KATAGO_PORT: "${KATAGO_PORT:-2388}"
       KATAGO_ANALYSIS_THREADS: "${KATAGO_ANALYSIS_THREADS:-8}"
-      KATAGO_VISITS: "${KATAGO_VISITS:-800}"
-      KATAGO_SEARCH_THREADS: "${KATAGO_SEARCH_THREADS:-8}"
+      # Set to positive integers to override the corresponding values in analysis.cfg at runtime.
+      KATAGO_VISITS: "${KATAGO_VISITS:-}"
+      KATAGO_SEARCH_THREADS: "${KATAGO_SEARCH_THREADS:-}"
       KATAGO_CONFIG: /config/analysis.cfg
       NVIDIA_VISIBLE_DEVICES: all
       NVIDIA_DRIVER_CAPABILITIES: compute,utility

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,6 +6,28 @@ CFG=""
 PORT="${KATAGO_PORT:-2388}"
 THREADS="${KATAGO_ANALYSIS_THREADS:-8}"
 
+validate_positive_integer() {
+  local name="$1"
+  local value="$2"
+
+  if [[ ! "$value" =~ ^[0-9]+$ ]] || [ "$value" -le 0 ]; then
+    echo "${name} must be a positive integer. Got: ${value}" >&2
+    exit 1
+  fi
+}
+
+OVERRIDE_ARGS=()
+
+if [[ -n "${KATAGO_VISITS:-}" ]]; then
+  validate_positive_integer "KATAGO_VISITS" "${KATAGO_VISITS}"
+  OVERRIDE_ARGS+=(-override-config "maxVisits=${KATAGO_VISITS}")
+fi
+
+if [[ -n "${KATAGO_SEARCH_THREADS:-}" ]]; then
+  validate_positive_integer "KATAGO_SEARCH_THREADS" "${KATAGO_SEARCH_THREADS}"
+  OVERRIDE_ARGS+=(-override-config "numSearchThreadsPerAnalysisThread=${KATAGO_SEARCH_THREADS}")
+fi
+
 if [[ -n "${KATAGO_CONFIG:-}" ]] && [ -f "${KATAGO_CONFIG}" ]; then
   CFG="${KATAGO_CONFIG}"
 elif [ -f /config/analysis.cfg ]; then
@@ -72,8 +94,16 @@ fi
 
 echo "Starting KataGo analysis @ 0.0.0.0:${PORT} with model $REAL_MODEL and config $REAL_CFG"
 
-exec /opt/katago/katago analysis \
-  -model "$REAL_MODEL" \
-  -config "$REAL_CFG" \
-  -analysis-threads "$THREADS" \
+CMD=(
+  /opt/katago/katago analysis
+  -model "$REAL_MODEL"
+  -config "$REAL_CFG"
+  -analysis-threads "$THREADS"
   -analysis-addr "0.0.0.0:${PORT}"
+)
+
+if ((${#OVERRIDE_ARGS[@]})); then
+  CMD+=("${OVERRIDE_ARGS[@]}")
+fi
+
+exec "${CMD[@]}"


### PR DESCRIPTION
## Summary
- allow the docker entrypoint to read optional KATAGO_VISITS and KATAGO_SEARCH_THREADS overrides after validating they are positive integers
- forward those overrides to katago analysis via -override-config so they take precedence over analysis.cfg when present
- document the new environment variables in the Compose file and README

## Testing
- bash -n docker/entrypoint.sh

------
https://chatgpt.com/codex/tasks/task_e_68d1c10c99488324948ce557e178d3fb