### PR TITLE
Decouple container and host ports for analysis service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
       KATAGO_MODEL: /models/latest.bin.gz
       KATAGO_PORT: "${KATAGO_PORT:-2388}"
+      KATAGO_CONTAINER_PORT: "${KATAGO_CONTAINER_PORT:-2388}"
       KATAGO_ANALYSIS_THREADS: "${KATAGO_ANALYSIS_THREADS:-8}"
       # Set to positive integers to override the corresponding values in analysis.cfg at runtime.
       KATAGO_VISITS: "${KATAGO_VISITS:-}"
@@ -18,7 +19,7 @@ services:
       NVIDIA_VISIBLE_DEVICES: all
       NVIDIA_DRIVER_CAPABILITIES: compute,utility
     ports:
-      - "127.0.0.1:${KATAGO_PORT:-2388}:2388"
+      - "127.0.0.1:${KATAGO_PORT:-2388}:${KATAGO_CONTAINER_PORT:-2388}"
     volumes:
       - ./models:/models:ro
       - ./config:/config:ro

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 MODEL="${KATAGO_MODEL:-/models/latest.bin.gz}"
 CFG=""
-PORT="${KATAGO_PORT:-2388}"
+CONTAINER_PORT="${KATAGO_CONTAINER_PORT:-2388}"
+HOST_PORT="${KATAGO_PORT:-${CONTAINER_PORT}}"
 THREADS="${KATAGO_ANALYSIS_THREADS:-8}"
 
 validate_positive_integer() {
@@ -92,14 +93,14 @@ if ! compgen -G "/dev/nvidia*" >/dev/null 2>&1; then
   fi
 fi
 
-echo "Starting KataGo analysis @ 0.0.0.0:${PORT} with model $REAL_MODEL and config $REAL_CFG"
+echo "Starting KataGo analysis @ 0.0.0.0:${CONTAINER_PORT} (host port ${HOST_PORT}) with model $REAL_MODEL and config $REAL_CFG"
 
 CMD=(
   /opt/katago/katago analysis
   -model "$REAL_MODEL"
   -config "$REAL_CFG"
   -analysis-threads "$THREADS"
-  -analysis-addr "0.0.0.0:${PORT}"
+  -analysis-addr "0.0.0.0:${CONTAINER_PORT}"
 )
 
 if ((${#OVERRIDE_ARGS[@]})); then


### PR DESCRIPTION
## Summary
- add a dedicated container port variable in the entrypoint and keep the analysis server bound to it
- extend docker-compose to expose the configurable container port while allowing host port overrides

## Testing
- `KATAGO_PORT=2399 docker compose up -d --build` *(fails: docker not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c37e6acc8324b263b5e5be4986e1