### PR TITLE
Allow configuring KataGo CUDA release asset

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,7 @@
 FROM nvidia/cuda:12.5.1-cudnn8-runtime-ubuntu24.04
 
 ARG KATAGO_VER=v1.16.2
+ARG CUDA_FLAVOR=cuda12.5-cudnn8.9.7
 WORKDIR /opt/katago
 
 # Minimal deps
@@ -12,7 +13,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
 # Fetch KataGo release (Linux CUDA build)
 # Verify checksums in production if desired.
 RUN curl -L -o katago.zip \
-    "https://github.com/lightvector/KataGo/releases/download/${KATAGO_VER}/KataGo-${KATAGO_VER}-Linux-x64-cuda.zip" \
+    "https://github.com/lightvector/KataGo/releases/download/${KATAGO_VER}/katago-${KATAGO_VER}-${CUDA_FLAVOR}-linux-x64.zip" \
  && unzip katago.zip -d /opt/katago \
  && rm katago.zip \
  && chmod +x /opt/katago/katago


### PR DESCRIPTION
## Summary
- add a CUDA_FLAVOR build argument so the Docker image can request the correct KataGo CUDA artifact
- update the download URL to match the published katago CUDA asset naming

## Testing
- not run (docker CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d1c4f4040c8324ba2b8f9bb6cfe3ff