### PR TITLE
Align container and host port mapping

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -10,7 +10,7 @@ services:
       - KATAGO_MODEL=/models/${KATAGO_MODEL_FILE:-latest.bin.gz}
       - KATAGO_PORT=${KATAGO_PORT:-2388}
     ports:
-      - "127.0.0.1:${KATAGO_PORT:-2388}:2388"
+      - "127.0.0.1:${KATAGO_PORT:-2388}:${KATAGO_PORT:-2388}"
     volumes:
       - ./models:/models:ro
     deploy:


### PR DESCRIPTION
## Summary
- ensure the compose service maps both host and container ports to `${KATAGO_PORT}` so overrides use a consistent port

## Testing
- `docker compose up -d` *(fails: `docker` not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c59a956c8324ada3ce28145de7f7