### PR TITLE
Fix Quickstart directory name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## Quickstart
 ```bash
-cd Katago
+cd KataGo
 ./scripts/00_setup_dirs.sh
 ./scripts/01_get_model.sh   # follow prompt; save as models/latest.bin.gz
 ./scripts/02_build.sh


### PR DESCRIPTION
## Summary
- correct the Quickstart instructions to use the proper `KataGo` directory name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1c7427cf08324ab630eb9b264a72e