### PR TITLE
Use socat to forward KataGo analysis over TCP

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /opt/katago
 
 # Minimal deps
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    ca-certificates curl unzip python3-minimal netcat-openbsd \
+    ca-certificates curl unzip python3-minimal netcat-openbsd socat \
  && rm -rf /var/lib/apt/lists/*
 
 # Fetch KataGo release (Linux CUDA build)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -96,15 +96,23 @@ fi
 echo "Starting KataGo analysis @ 0.0.0.0:${CONTAINER_PORT} (host port ${HOST_PORT}) with model $REAL_MODEL and config $REAL_CFG"
 
 CMD=(
-  /opt/katago/katago analysis
+  /opt/katago/katago
+  analysis
   -model "$REAL_MODEL"
   -config "$REAL_CFG"
   -analysis-threads "$THREADS"
-  -analysis-addr "0.0.0.0:${CONTAINER_PORT}"
 )
 
 if ((${#OVERRIDE_ARGS[@]})); then
   CMD+=("${OVERRIDE_ARGS[@]}")
 fi
 
-exec "${CMD[@]}"
+printf -v KATAGO_CMD '%q ' "${CMD[@]}"
+KATAGO_CMD="${KATAGO_CMD% }"
+
+SOCAT_ARGS=(
+  "TCP-LISTEN:${CONTAINER_PORT},reuseaddr,fork"
+  "EXEC:${KATAGO_CMD}"
+)
+
+exec socat "${SOCAT_ARGS[@]}"


### PR DESCRIPTION
## Summary
- install socat in the CUDA runtime image for TCP forwarding support
- update the entrypoint to remove the unsupported -analysis-addr flag and forward traffic to the KataGo analysis process via socat

## Testing
- bash -n docker/entrypoint.sh

------
https://chatgpt.com/codex/tasks/task_e_68d23867e8448324b7fe383691c783ec