### PR TITLE
Update KataGo entrypoint analysis threads override

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,7 +5,6 @@ MODEL="${KATAGO_MODEL:-/models/latest.bin.gz}"
 CFG=""
 CONTAINER_PORT="${KATAGO_CONTAINER_PORT:-2388}"
 HOST_PORT="${KATAGO_PORT:-${CONTAINER_PORT}}"
-THREADS="${KATAGO_ANALYSIS_THREADS:-8}"
 
 validate_positive_integer() {
   local name="$1"
@@ -27,6 +26,11 @@ fi
 if [[ -n "${KATAGO_SEARCH_THREADS:-}" ]]; then
   validate_positive_integer "KATAGO_SEARCH_THREADS" "${KATAGO_SEARCH_THREADS}"
   OVERRIDE_ARGS+=(-override-config "numSearchThreadsPerAnalysisThread=${KATAGO_SEARCH_THREADS}")
+fi
+
+if [[ -n "${KATAGO_ANALYSIS_THREADS:-}" ]]; then
+  validate_positive_integer "KATAGO_ANALYSIS_THREADS" "${KATAGO_ANALYSIS_THREADS}"
+  OVERRIDE_ARGS+=(-override-config "numAnalysisThreads=${KATAGO_ANALYSIS_THREADS}")
 fi
 
 if [[ -n "${KATAGO_CONFIG:-}" ]] && [ -f "${KATAGO_CONFIG}" ]; then
@@ -100,7 +104,6 @@ CMD=(
   analysis
   -model "$REAL_MODEL"
   -config "$REAL_CFG"
-  -analysis-threads "$THREADS"
 )
 
 if ((${#OVERRIDE_ARGS[@]})); then


### PR DESCRIPTION
## Summary
- remove the dedicated -analysis-threads argument from the entrypoint command
- funnel KATAGO_ANALYSIS_THREADS through the override-config mechanism for numAnalysisThreads
- keep relying on the default numAnalysisThreads value from the bundled analysis.cfg

## Testing
- bash -n docker/entrypoint.sh

------
https://chatgpt.com/codex/tasks/task_e_68d2392f80808324a6d2a4bd6b5b8a5c