### PR TITLE
Handle explicit model paths in run script

### DIFF
--- a/scripts/03_run.sh
+++ b/scripts/03_run.sh
@@ -3,11 +3,15 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 MODEL_FILE="${KATAGO_MODEL_FILE:-latest.bin.gz}"
-MODEL_PATH="models/${MODEL_FILE}"
+if [[ "${MODEL_FILE}" == */* ]]; then
+  MODEL_PATH="${MODEL_FILE}"
+else
+  MODEL_PATH="models/${MODEL_FILE}"
+fi
 
 # Require a gzip’d KataGo network file name.
-if [[ "${MODEL_FILE}" != *.bin.gz ]]; then
-  echo "Error: KATAGO_MODEL_FILE must point to a .bin.gz file (got: ${MODEL_FILE})." >&2
+if [[ "${MODEL_PATH}" != *.bin.gz ]]; then
+  echo "Error: KATAGO_MODEL_FILE must point to a .bin.gz file (got: ${MODEL_PATH})." >&2
   echo "Please double-check the model filename and try again." >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
- resolve KATAGO model paths that already include directories without forcing them under models/
- keep validating the network filename while pointing error messaging at the resolved path

## Testing
- PATH="$(pwd)/tmpbin:$PATH" KATAGO_MODEL_FILE=latest.bin.gz bash scripts/03_run.sh
- PATH="$(pwd)/tmpbin:$PATH" KATAGO_MODEL_FILE=models/foo.bin.gz bash scripts/03_run.sh

------
https://chatgpt.com/codex/tasks/task_e_68d23bebaf1083249745a4945c6d9369