### PR TITLE
Add configurable CUDA architectures for Docker builds

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,5 +1,7 @@
 FROM nvidia/cuda:12.4.1-devel-ubuntu22.04
 
+ARG CUDA_ARCHITECTURES=native
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         git \
@@ -12,9 +14,15 @@ RUN apt-get update \
 
 RUN git clone --depth 1 --branch v1.16.3 https://github.com/lightvector/KataGo.git /src/katago
 
-RUN cmake -S /src/katago/cpp -B /src/build \
-    -DUSE_BACKEND=CUDA \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_CUDA_ARCHITECTURES=86
+RUN set -eux; \
+    if [ -n "${CUDA_ARCHITECTURES}" ]; then \
+        ARCH_FLAG="-DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCHITECTURES}"; \
+    else \
+        ARCH_FLAG=""; \
+    fi; \
+    cmake -S /src/katago/cpp -B /src/build \
+        -DUSE_BACKEND=CUDA \
+        -DCMAKE_BUILD_TYPE=Release \
+        ${ARCH_FLAG:+$ARCH_FLAG}
 
 RUN cmake --build /src/build -j"$(nproc)"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,24 @@ You can also override `analysis.cfg` values without editing the file by exportin
 the entrypoint passes them to `katago analysis` via `-override-config`, taking precedence over the base configuration. Leave them
 unset (or empty) to keep the values defined in `analysis.cfg`.
 
+### Building for specific CUDA architectures
+
+The helper script `build_and_extract.sh` compiles the KataGo CUDA binary inside Docker. By default it requests `native` architectures,
+which lets CMake choose an appropriate target for the build container's GPU stack. To explicitly compile kernels for multiple GPU
+generations, set the semicolon-delimited list of architectures (for example `"75;80;86;89"`) via either the `CUDA_ARCHITECTURES`
+environment variable or the script flag:
+
+```bash
+# Environment variable
+CUDA_ARCHITECTURES="75;80;86;89" ./build_and_extract.sh
+
+# Command-line flag
+./build_and_extract.sh --cuda-architectures "75;80;86;89"
+```
+
+Passing an empty string (for example, `CUDA_ARCHITECTURES= ./build_and_extract.sh`) omits the CMake flag so KataGo detects supported
+architectures at runtime instead of during compilation.
+
 ## KaTrain configuration
 
 KaTrain connects to KataGo through its JSON analysis engine over a socket. Configure the engine in KaTrain → Settings → Engine:

--- a/build_and_extract.sh
+++ b/build_and_extract.sh
@@ -4,9 +4,54 @@ set -euo pipefail
 IMAGE="katago-build:fix"
 CONTAINER="kb"
 
+usage() {
+    cat <<'EOF'
+Usage: build_and_extract.sh [--cuda-architectures <value>]
+
+Build the KataGo CUDA binary inside Docker and copy it to the current directory.
+
+Options:
+  --cuda-architectures <value>  Override the CUDA architectures passed to CMake.
+                                Use a semicolon-separated list (e.g. "75;80;86;89"),
+                                "native" to auto-select based on the build image, or
+                                an empty string to let CMake detect at runtime.
+  -h, --help                    Show this help message and exit.
+EOF
+}
+
+cuda_architectures="${CUDA_ARCHITECTURES:-native}"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --cuda-architectures=*)
+            cuda_architectures="${1#*=}"
+            shift
+            ;;
+        --cuda-architectures)
+            shift
+            if [[ $# -eq 0 ]]; then
+                echo "Error: --cuda-architectures requires a value." >&2
+                exit 1
+            fi
+            cuda_architectures="$1"
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
 rm -f katago
 
-docker build -f Dockerfile.build -t "${IMAGE}" .
+docker build -f Dockerfile.build -t "${IMAGE}" . \
+    --build-arg CUDA_ARCHITECTURES="${cuda_architectures}"
 
 docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
 docker create --name "${CONTAINER}" "${IMAGE}"
@@ -15,4 +60,4 @@ docker cp "${CONTAINER}:/src/build/katago" ./katago
 
 docker rm "${CONTAINER}"
 
-./katago version
+./katago version --cuda-architectures


### PR DESCRIPTION
## Summary
- add a CUDA_ARCHITECTURES build arg to the Dockerfile and thread it into the CMake invocation
- let build_and_extract.sh forward environment or CLI overrides for the architecture list and document the option
- describe how to customize the architectures in the README

## Testing
- CUDA_ARCHITECTURES="75;80;86;89" ./build_and_extract.sh *(fails: docker: command not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d23db947988324a68a53ab6f69b57a