### PR TITLE
Fix docker build args order in script

### DIFF
--- a/build_and_extract.sh
+++ b/build_and_extract.sh
@@ -50,8 +50,11 @@ done
 
 rm -f katago
 
-docker build -f Dockerfile.build -t "${IMAGE}" . \
-    --build-arg CUDA_ARCHITECTURES="${cuda_architectures}"
+docker build \
+    -f Dockerfile.build \
+    -t "${IMAGE}" \
+    --build-arg CUDA_ARCHITECTURES="${cuda_architectures}" \
+    .
 
 docker rm -f "${CONTAINER}" >/dev/null 2>&1 || true
 docker create --name "${CONTAINER}" "${IMAGE}"


### PR DESCRIPTION
## Summary
- ensure build_and_extract.sh passes docker build arguments before the context by moving the trailing '.' to a separate line

## Testing
- ./build_and_extract.sh --cuda-architectures native *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d23f71bd6483249ee7b10f1e193733