### PR TITLE
Make KATAGO_ANALYSIS_THREADS opt-in override

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,10 @@ docker compose logs -f katago
 ./scripts/04_benchmark.sh   # queries the KataGo analysis engine and prints JSON
 ```
 
-To change how many CPU threads KataGo uses for analysis, export `KATAGO_ANALYSIS_THREADS` before starting the container, for example:
-
-```bash
-export KATAGO_ANALYSIS_THREADS=16
-docker compose up -d
-```
+To override how many CPU threads KataGo uses for analysis, export `KATAGO_ANALYSIS_THREADS` before starting the container. For
+example, setting `export KATAGO_ANALYSIS_THREADS=16` and then running `docker compose up -d` asks the entrypoint to pass
+`numAnalysisThreads=16` to KataGo. If you leave `KATAGO_ANALYSIS_THREADS` unset (or explicitly set it to an empty string), the
+entrypoint omits the override and KataGo honors the value already defined in `config/analysis.cfg`.
 
 You can also override `analysis.cfg` values without editing the file by exporting `KATAGO_VISITS` (maps to `maxVisits`) or
 `KATAGO_SEARCH_THREADS` (maps to `numSearchThreadsPerAnalysisThread`). When these environment variables are set to positive integers,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       KATAGO_MODEL: /models/latest.bin.gz
       KATAGO_PORT: "${KATAGO_PORT:-2388}"
       KATAGO_CONTAINER_PORT: "${KATAGO_CONTAINER_PORT:-2388}"
-      KATAGO_ANALYSIS_THREADS: "${KATAGO_ANALYSIS_THREADS:-8}"
+      KATAGO_ANALYSIS_THREADS: "${KATAGO_ANALYSIS_THREADS:-}"
       # Set to positive integers to override the corresponding values in analysis.cfg at runtime.
       KATAGO_VISITS: "${KATAGO_VISITS:-}"
       KATAGO_SEARCH_THREADS: "${KATAGO_SEARCH_THREADS:-}"


### PR DESCRIPTION
## Summary
- stop docker compose from defaulting `KATAGO_ANALYSIS_THREADS` so the entrypoint only overrides when the host sets a value
- clarify the README instructions that the environment variable must be set to override and leaving it unset defers to `config/analysis.cfg`

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d2419c11b88324ba9abec5ce9117ca