### PR TITLE
Ensure katago binary installed at fixed path

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
 RUN curl -L -o katago.zip \
     "https://github.com/lightvector/KataGo/releases/download/${KATAGO_VER}/katago-${KATAGO_VER}-${KATAGO_FLAVOR}.zip" \
  && unzip katago.zip -d /opt/katago \
+ && mv "/opt/katago/katago-${KATAGO_VER}-${KATAGO_FLAVOR}/katago" /opt/katago/katago \
  && rm katago.zip \
+ && rm -rf "/opt/katago/katago-${KATAGO_VER}-${KATAGO_FLAVOR}" \
  && chmod +x /opt/katago/katago
 
 # Config + entrypoint


### PR DESCRIPTION
## Summary
- move the extracted KataGo binary into /opt/katago/katago during image build
- remove the now-unneeded versioned extraction directory after relocating the binary

## Testing
- `docker build -f docker/Dockerfile -t katago-test .` *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d246ceb99c83249e7f26d52e587344