### PR TITLE
Fix Dockerfile COPY paths

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,8 +20,8 @@ RUN curl -L -o katago.zip \
  && chmod +x /opt/katago/katago
 
 # Config + entrypoint
-COPY analysis.cfg /opt/katago/analysis.cfg
-COPY entrypoint.sh /entrypoint.sh
+COPY docker/analysis.cfg /opt/katago/analysis.cfg
+COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 # Models mounted at /models


### PR DESCRIPTION
## Summary
- point Dockerfile COPY commands at files within the docker/ directory

## Testing
- docker compose build *(fails: docker not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d248a8879883248f24b99bdcd95a96