### PR TITLE
Fix Docker runtime to use cuDNN 8 zip release and expose config

### DIFF
--- a/config/analysis.cfg
+++ b/config/analysis.cfg
@@ -1,8 +1,8 @@
-# Minimal, safe defaults; tune later.
-# Lower visit count helps KataGo respond quickly on modest GPUs/CPUs.
+# KataGo analysis configuration tuned for remote JSON clients
 maxVisits = 200
 numAnalysisThreads = 8
+numSearchThreads = 16
 nnCacheSizePowerOfTwo = 20
 nnMutexPoolSizePowerOfTwo = 16
 allowSlowEngine = true
-reportAnalysisWinratesAs = "BLACK"   # GUI can flip
+reportAnalysisWinratesAs = "BLACK"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ services:
       KATAGO_PORT: "${KATAGO_PORT:-2388}"
       KATAGO_CONTAINER_PORT: "${KATAGO_CONTAINER_PORT:-2388}"
       KATAGO_ANALYSIS_THREADS: "${KATAGO_ANALYSIS_THREADS:-}"
-      # Set to positive integers to override the corresponding values in analysis.cfg at runtime.
       KATAGO_VISITS: "${KATAGO_VISITS:-}"
       KATAGO_SEARCH_THREADS: "${KATAGO_SEARCH_THREADS:-}"
       KATAGO_CONFIG: /config/analysis.cfg
@@ -22,7 +21,7 @@ services:
       - "127.0.0.1:${KATAGO_PORT:-2388}:${KATAGO_CONTAINER_PORT:-2388}"
     volumes:
       - ./models:/models:ro
-      - ./config:/config:ro
+      - ./config/analysis.cfg:/config/analysis.cfg:ro
     deploy:
       resources:
         reservations:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,29 +1,32 @@
-# CUDA-enabled KataGo runtime
-FROM nvidia/cuda:12.5.1-runtime-ubuntu24.04
+# CUDA-enabled KataGo runtime built on a cuDNN 8 base image
+FROM nvidia/cuda:12.2.2-cudnn8-runtime-ubuntu22.04
 
 ARG KATAGO_VER=v1.16.3
-ARG KATAGO_FLAVOR=cuda12.5-cudnn8.9.7-linux-x64
+ARG KATAGO_FLAVOR=cuda12.2-cudnn8-linux-x64
 WORKDIR /opt/katago
 
-# Minimal deps
+# Install minimal runtime dependencies
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    ca-certificates curl unzip python3-minimal netcat-openbsd socat \
+    ca-certificates \
+    curl \
+    unzip \
+    socat \
+    python3-minimal \
  && rm -rf /var/lib/apt/lists/*
 
-# Fetch KataGo release (Linux CUDA build)
-RUN curl -L -o katago.zip \
+# Fetch KataGo release (use ZIP to avoid AppImage/FUSE issues)
+RUN curl -fsSL -o katago.zip \
     "https://github.com/lightvector/KataGo/releases/download/${KATAGO_VER}/katago-${KATAGO_VER}-${KATAGO_FLAVOR}.zip" \
  && unzip -j katago.zip -d /opt/katago \
  && rm katago.zip \
  && chmod +x /opt/katago/katago
 
-# Config + entrypoint
-COPY docker/analysis.cfg /opt/katago/analysis.cfg
+# Provide a default analysis configuration inside the image
+COPY config/analysis.cfg /opt/katago/analysis.cfg
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-# Models mounted at /models
-VOLUME ["/models"]
+VOLUME ["/models", "/config"]
 
 EXPOSE 2388
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- switch the runtime image to NVIDIA CUDA 12.2 with bundled cuDNN 8 and download KataGo from the ZIP release to avoid AppImage/FUSE issues
- copy the host analysis configuration into the image and ensure the compose volume mounts the edited file directly
- add numSearchThreads to the analysis config so KataGo no longer crashes due to the missing key

## Testing
- not run (infrastructure only change)


------
https://chatgpt.com/codex/tasks/task_e_68d28554b21483249d72bcef538271bb