### PR TITLE
Update docker compose to allow fuse access

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,12 @@ services:
     volumes:
       - ./models:/models:ro
       - ./config/analysis.cfg:/config/analysis.cfg:ro
+    devices:
+      - /dev/fuse:/dev/fuse:rwm
+    cap_add:
+      - SYS_ADMIN
+    security_opt:
+      - apparmor:unconfined
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
## Summary
- add FUSE device mapping for the katago service container
- grant SYS_ADMIN capability and disable AppArmor confinement to support FUSE

## Testing
- ⚠️ `docker compose config` *(fails: docker not installed in environment)*
- ⚠️ `docker compose up` *(fails: docker not installed in environment)*
- ⚠️ `docker exec katago-analysis ls -l /dev/fuse` *(fails: docker not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d29a56657c8324b9c2dff866eb8718