### PR TITLE
Finalize 2.1 GPU JSON service runtime and tooling

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,2 @@
-KATAGO_VER=v1.16.2
-KATAGO_MODEL_FILE=latest.bin.gz
-KATAGO_PORT=2388
+KATAGO_CONFIG=/config/analysis.cfg
+PORT=2388

--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
-# KataGo JSON Analysis Service (2.0)
+# KataGo JSON Analysis Service (2.1)
 
-Dockerized KataGo JSON analysis server tuned for Ubuntu 24.04 hosts with NVIDIA GPUs. The runtime image downloads the official CUDA 12.5 build of KataGo v1.16.3 and exposes the JSON API on port 2388.
+Dockerized KataGo JSON analysis server tuned for Ubuntu 24.04 hosts with NVIDIA GPUs. The runtime image is based on
+`nvidia/cuda:12.5.1-cudnn-runtime-ubuntu24.04`, downloads the official CUDA 12.5 build of KataGo v1.16.3, and exposes the
+JSON API on port 2388.
+
+## What's new in 2.1
+
+- Local-first Docker Compose workflow that always builds the image from source before running.
+- Host-mounted configuration respected via `${KATAGO_CONFIG:-/config/analysis.cfg}` so local edits take effect immediately.
+- Compose GPU reservation stanza requests all NVIDIA GPUs using the standard `deploy.resources.reservations.devices` block.
+- Helper scripts are idempotent and safe to re-run; they create directories, refresh models, rebuild images, and verify the
+  JSON endpoint automatically.
 
 ## Prerequisites
 
@@ -17,22 +27,28 @@ cd KataGo
 ./scripts/00_setup_dirs.sh            # creates config/ and models/; copies config/analysis.cfg if missing
 ./scripts/01_get_model.sh              # downloads the newest kata1 network and links models/latest.bin.gz
 ./scripts/02_build.sh                  # builds katago-json:${GIT_SHA:-local}
-./scripts/03_run.sh                    # launches the JSON analysis service
+./scripts/03_run.sh                    # launches the JSON analysis service and waits for health
 curl -fsS http://127.0.0.1:2388 \
   -H 'Content-Type: application/json' \
   -d '{"id":"ping","action":"query_version"}' | python3 -m json.tool
 ```
 
-The final `curl` command is the same request used by the container healthcheck. Successful responses include the KataGo version and indicate the GPU-enabled analysis service is ready.
+The final `curl` command is the same request used by the container healthcheck. Successful responses include the KataGo version
+and indicate the GPU-enabled analysis service is ready.
 
 ## Configuration and models
 
-- `config/analysis.cfg` is mounted read-only into the container. Edit it locally to adjust analysis parameters. The container also forces `allowResignation=false` via `-override-config` so KataGo never resigns during analysis sessions.
-- Models in `models/` are mounted read-only. The runtime expects `/models/latest.bin.gz`; the helper script maintains this symlink so you can keep multiple networks side by side.
+- `config/analysis.cfg` is mounted read-only into the container. Edit it locally to adjust analysis parameters. The container also
+  forces `allowResignation=false` via `-override-config` so KataGo never resigns during analysis sessions.
+- `KATAGO_CONFIG` defaults to `/config/analysis.cfg`; override it in `.env` if you mount the config elsewhere.
+- Models in `models/` are mounted read-only. The runtime expects `/models/latest.bin.gz`; the helper script maintains this symlink so
+  you can keep multiple networks side by side.
 
 ## Compose details
 
-`compose.yaml` builds the image locally (`katago-json:${GIT_SHA:-local}`), publishes port `2388`, mounts the configuration and models directories read-only, and reserves all NVIDIA GPUs using the Compose `deploy.resources.reservations.devices` stanza. The container healthcheck posts `query_version` to the JSON endpoint to verify readiness.
+`compose.yaml` builds the image locally (`katago-json:${GIT_SHA:-local}`), publishes port `2388`, mounts the configuration and
+models directories read-only, and reserves all NVIDIA GPUs using the Compose `deploy.resources.reservations.devices` stanza. The
+container healthcheck posts `query_version` to the JSON endpoint to verify readiness.
 
 ## References
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,8 +4,12 @@ services:
       context: .
       dockerfile: docker/Dockerfile
     image: katago-json:${GIT_SHA:-local}
+    environment:
+      PORT: "${PORT:-2388}"
+      KATAGO_CONFIG: "${KATAGO_CONFIG:-/config/analysis.cfg}"
+      KATAGO_MODEL: "/models/latest.bin.gz"
     ports:
-      - "2388:2388"
+      - "${PORT:-2388}:${PORT:-2388}"
     volumes:
       - ./config:/config:ro
       - ./models:/models:ro
@@ -15,9 +19,16 @@ services:
           devices:
             - driver: nvidia
               count: all
-              capabilities: [gpu]
+              capabilities:
+                - gpu
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://127.0.0.1:2388 -H 'Content-Type: application/json' -d '{\"id\":\"ping\",\"action\":\"query_version\"}' >/dev/null || exit 1"]
+      test:
+        - CMD-SHELL
+        - >
+          curl -fsS -X POST http://127.0.0.1:${PORT:-2388}
+          -H 'Content-Type: application/json'
+          -d '{"id":"ping","action":"query_version"}'
+          >/dev/null
       interval: 10s
       timeout: 3s
       retries: 10

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,43 +1,44 @@
-FROM nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04
-WORKDIR /opt/katago
+FROM nvidia/cuda:12.5.1-cudnn-runtime-ubuntu24.04 AS downloader
 
 ARG KATAGO_VER=v1.16.3
-ARG KATAGO_FLAVOR=cuda12.8-cudnn9.8.0-linux-x64
+ARG KATAGO_FLAVOR=cuda12.5-cudnn8.9.7-linux-x64
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    python3 \
+WORKDIR /tmp/katago
+
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
     unzip \
-    libzip4t64 \
   && rm -rf /var/lib/apt/lists/*
 
 RUN set -eux; \
   curl -fL -o katago.zip \
     "https://github.com/lightvector/KataGo/releases/download/${KATAGO_VER}/katago-${KATAGO_VER}-${KATAGO_FLAVOR}.zip"; \
-  unzip -j katago.zip -d /opt/katago; rm -f katago.zip
+  unzip -j katago.zip katago; \
+  rm katago.zip
 
-RUN set -eux; cd /opt/katago; \
-  F="$(find . -maxdepth 1 -type f -iregex '\./katago(\\.appimage)?' | head -n1 | sed 's|^./||')"; \
-  if [ -z "$F" ]; then \
-    F="$(find . -maxdepth 1 -type f -iname 'katago*' | head -n1 | sed 's|^./||')"; \
-  fi; \
-  if [ -z "$F" ]; then \
-    echo "Unable to locate KataGo binary or AppImage in extracted archive" >&2; exit 1; \
-  fi; \
-  chmod +x "$F"; "./$F" --appimage-extract >/dev/null 2>&1 || true; \
-  if [ -d squashfs-root ]; then \
-    mv squashfs-root /opt/katago/app; \
-    printf '#!/bin/sh\nexec /opt/katago/app/AppRun "$@"\n' > /opt/katago/katago; \
-    rm -f "$F"; \
-  else \
-    mv "$F" /opt/katago/katago; \
-  fi; chmod +x /opt/katago/katago
+FROM nvidia/cuda:12.5.1-cudnn-runtime-ubuntu24.04
 
-COPY docker/analysis.cfg /opt/katago/analysis.cfg
-COPY docker/*.py /opt/katago/
-COPY docker/entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    python3 \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --create-home --shell /usr/sbin/nologin katago
+
+WORKDIR /opt/katago
+
+COPY --from=downloader /tmp/katago/katago /opt/katago/katago
+COPY docker/serve.py /opt/katago/serve.py
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+RUN chmod 755 /opt/katago/katago /opt/katago/serve.py /usr/local/bin/entrypoint.sh \
+  && chown -R katago:katago /opt/katago /usr/local/bin/entrypoint.sh
+
+USER katago
 
 EXPOSE 2388
-CMD ["/entrypoint.sh"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,9 +2,9 @@
 set -euo pipefail
 
 MODEL="${KATAGO_MODEL:-/models/latest.bin.gz}"
-CFG=""
-CONTAINER_PORT="${KATAGO_CONTAINER_PORT:-2388}"
-HOST_PORT="${KATAGO_PORT:-${CONTAINER_PORT}}"
+CFG="${KATAGO_CONFIG:-/config/analysis.cfg}"
+PORT="${PORT:-2388}"
+LISTEN_ADDR="${KATAGO_LISTEN:-0.0.0.0}"
 
 validate_positive_integer() {
   local name="$1"
@@ -16,7 +16,7 @@ validate_positive_integer() {
   fi
 }
 
-CONFIG_OVERRIDES=()
+CONFIG_OVERRIDES=("allowResignation=false")
 
 NN_MAX_BATCH_SIZE="${KATAGO_NN_MAX_BATCH_SIZE:-32}"
 if [[ -n "${NN_MAX_BATCH_SIZE}" ]]; then
@@ -39,16 +39,14 @@ if [[ -n "${KATAGO_ANALYSIS_THREADS:-}" ]]; then
   CONFIG_OVERRIDES+=("numAnalysisThreads=${KATAGO_ANALYSIS_THREADS}")
 fi
 
-if [[ -n "${KATAGO_CONFIG:-}" ]] && [ -f "${KATAGO_CONFIG}" ]; then
-  CFG="${KATAGO_CONFIG}"
-elif [ -f /config/analysis.cfg ]; then
-  CFG="/config/analysis.cfg"
-elif [ -f /opt/katago/analysis.cfg ]; then
-  CFG="/opt/katago/analysis.cfg"
+if [[ -z "${CFG}" ]]; then
+  echo "No KataGo analysis configuration path provided via KATAGO_CONFIG." >&2
+  exit 1
 fi
 
-if [[ -z "${CFG}" ]]; then
-  echo "No KataGo analysis configuration file found. Set KATAGO_CONFIG or bind /config/analysis.cfg." >&2
+if [[ ! -f "${CFG}" ]]; then
+  echo "Config not found at ${CFG}" >&2
+  ls -l "$(dirname "${CFG}")" || true
   exit 1
 fi
 
@@ -57,15 +55,9 @@ if [[ -z "${MODEL}" ]]; then
   exit 1
 fi
 
-if [ ! -f "$MODEL" ]; then
-  echo "Model not found at $MODEL"
+if [[ ! -f "${MODEL}" ]]; then
+  echo "Model not found at ${MODEL}" >&2
   ls -l /models || true
-  exit 1
-fi
-
-if [ ! -f "$CFG" ]; then
-  echo "Config not found at $CFG" >&2
-  ls -l "$(dirname "$CFG")" || true
   exit 1
 fi
 
@@ -73,48 +65,49 @@ REAL_MODEL="$(readlink -f "$MODEL")"
 REAL_CFG="$(readlink -f "$CFG")"
 
 if [[ "${REAL_MODEL}" != /models/* ]]; then
-  echo "Model file must live under /models. Found: ${REAL_MODEL}"
+  echo "Model file must live under /models. Found: ${REAL_MODEL}" >&2
   exit 1
 fi
 
-if [[ "${REAL_CFG}" != /config/* && "${REAL_CFG}" != /opt/katago/* ]]; then
-  echo "Config file must be under /config or /opt/katago. Found: ${REAL_CFG}" >&2
+if [[ "${REAL_CFG}" != /config/* ]]; then
+  echo "Config file must be under /config. Found: ${REAL_CFG}" >&2
   exit 1
 fi
 
 if [[ ! "$(basename "$REAL_MODEL")" =~ ^kata1.*\.bin\.gz$ ]]; then
-  echo "Incompatible network detected: $(basename "$REAL_MODEL")"
+  echo "Incompatible network detected: $(basename "$REAL_MODEL")" >&2
   exit 1
 fi
 
 if ! gzip -t "$REAL_MODEL"; then
-  echo "Network file $(basename "$REAL_MODEL") failed gzip integrity check"
+  echo "Network file $(basename "$REAL_MODEL") failed gzip integrity check" >&2
   exit 1
 fi
 
-# Check for NVIDIA GPU devices
-if ! compgen -G "/dev/nvidia*" >/dev/null 2>&1; then
-  if ! command -v nvidia-smi >/dev/null 2>&1 || ! nvidia-smi >/dev/null 2>&1; then
-    echo "No NVIDIA devices detected. Ensure the NVIDIA Container Toolkit / GPU runtime is installed and the container is started with GPU access." >&2
-    exit 1
-  else
-    echo "nvidia-smi found but /dev/nvidia* devices missing; GPU device nodes may not be exposed."
-    exit 1
-  fi
+if ! command -v nvidia-smi >/dev/null 2>&1; then
+  echo "nvidia-smi command not found; ensure NVIDIA Container Toolkit is configured." >&2
+  exit 1
 fi
 
-echo "Starting KataGo analysis @ 0.0.0.0:${CONTAINER_PORT} (host port ${HOST_PORT}) with model $REAL_MODEL and config $REAL_CFG"
+if ! nvidia-smi >/dev/null 2>&1; then
+  echo "nvidia-smi failed; GPU may be unavailable. Verify GPU access." >&2
+  exit 1
+fi
+
+validate_positive_integer "PORT" "${PORT}"
+
+echo "Starting KataGo analysis @ ${LISTEN_ADDR}:${PORT} with model ${REAL_MODEL} and config ${REAL_CFG}" >&2
 
 PROXY_ARGS=(
-  --listen 0.0.0.0
-  --port "$CONTAINER_PORT"
+  --listen "${LISTEN_ADDR}"
+  --port "${PORT}"
   --katago /opt/katago/katago
-  --model "$REAL_MODEL"
-  --config "$REAL_CFG"
+  --model "${REAL_MODEL}"
+  --config "${REAL_CFG}"
 )
 
 for override in "${CONFIG_OVERRIDES[@]}"; do
-  PROXY_ARGS+=(--override-config "$override")
+  PROXY_ARGS+=(--override-config "${override}")
 done
 
 exec python3 /opt/katago/serve.py "${PROXY_ARGS[@]}"

--- a/scripts/01_get_model.sh
+++ b/scripts/01_get_model.sh
@@ -59,10 +59,11 @@ PY
 filename="${model_url##*/}"
 dest_path="${MODELS_DIR}/${filename}"
 
+tmp_file="${dest_path}.tmp"
+
 if [ -f "${dest_path}" ]; then
   echo "${filename} already exists. Verifying integrity..."
 else
-  tmp_file="${dest_path}.tmp"
   echo "Downloading ${filename} from ${model_url}" >&2
   curl -fL "${model_url}" -o "${tmp_file}"
   mv "${tmp_file}" "${dest_path}"
@@ -72,9 +73,12 @@ fi
 if ! gzip -t "${dest_path}"; then
   echo "Network file ${dest_path} failed gzip integrity check." >&2
   echo "Re-download the file; incomplete downloads are not usable." >&2
-  rm -f "${dest_path}"
+  rm -f "${dest_path}" "${tmp_file}"
   exit 1
 fi
 
-ln -sf "${filename}" "${MODELS_DIR}/latest.bin.gz"
+link_tmp="${MODELS_DIR}/latest.bin.gz.tmp"
+ln -sfn "${filename}" "${link_tmp}"
+mv -Tf "${link_tmp}" "${MODELS_DIR}/latest.bin.gz"
+
 echo "Linked ${filename} as models/latest.bin.gz"

--- a/scripts/02_build.sh
+++ b/scripts/02_build.sh
@@ -2,5 +2,11 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
-export IMAGE_TAG="$(git rev-parse --short HEAD)"
+
+GIT_SHA="$(git rev-parse --short HEAD 2>/dev/null || true)"
+if [[ -z "${GIT_SHA}" ]]; then
+  GIT_SHA="local"
+fi
+export GIT_SHA
+
 docker compose build --no-cache

--- a/scripts/03_run.sh
+++ b/scripts/03_run.sh
@@ -3,5 +3,38 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+if [ -f .env ]; then
+  set -a
+  # shellcheck disable=SC1091
+  source .env
+  set +a
+fi
+
+PORT="${PORT:-2388}"
+HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-180}"
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required to probe the KataGo JSON endpoint." >&2
+  exit 1
+fi
+
 docker compose up -d
-docker compose ps
+
+deadline=$((SECONDS + HEALTH_TIMEOUT))
+
+printf 'Waiting for KataGo JSON service to become healthy'
+while (( SECONDS < deadline )); do
+  if curl -fsS -X POST "http://127.0.0.1:${PORT}" \
+    -H 'Content-Type: application/json' \
+    -d '{"id":"ping","action":"query_version"}' >/dev/null; then
+    echo " - healthy"
+    docker compose ps
+    exit 0
+  fi
+  printf '.'
+  sleep 3
+done
+
+printf '\nTimed out waiting for KataGo JSON service to become healthy.\n' >&2
+docker compose logs --tail 50 >&2
+exit 1


### PR DESCRIPTION
## Summary
- update the documentation to reflect the 2.1 release, CUDA 12.5.1 runtime base, and the new local-first workflow
- rebuild the runtime image on nvidia/cuda:12.5.1, download the official v1.16.3 CUDA-12.5 binary, run the JSON server as a non-root user, and enforce config/model expectations
- adjust compose defaults and helper scripts to honor host-mounted config, maintain the model symlink atomically, export GIT_SHA, and wait for the health-checked JSON endpoint

## Testing
- shellcheck scripts/00_setup_dirs.sh scripts/01_get_model.sh scripts/02_build.sh scripts/03_run.sh docker/entrypoint.sh

------
https://chatgpt.com/codex/tasks/task_e_68d2c65681c48324b29105583768fda3