### PR TITLE
Drain HTTP KataGo stdout

### DIFF
--- a/docker/serve.py
+++ b/docker/serve.py
@@ -137,19 +137,26 @@ class KataGoRequestHandler(socketserver.StreamRequestHandler):
                 text_body += "\n"
             proc.stdin.write(text_body)
             proc.stdin.flush()
-            response = proc.stdout.readline()
-        finally:
             try:
                 proc.stdin.close()  # type: ignore[call-arg]
             except Exception:
                 pass
+
+            responses: List[str] = []
+            while True:
+                line = proc.stdout.readline()
+                if not line:
+                    break
+                responses.append(line)
+        finally:
             proc.wait(timeout=5)
 
-        if not response:
+        if not responses:
             self._send_http_error(502, "No response from KataGo")
             return
 
-        payload = response.encode("utf-8")
+        response_text = "".join(responses)
+        payload = response_text.encode("utf-8")
         headers_out = (
             f"HTTP/1.1 200 OK\r\n"
             f"Content-Type: application/json\r\n"


### PR DESCRIPTION
## Summary
- drain KataGo stdout for HTTP requests until EOF before responding
- collect all JSON lines and return them as a complete payload so clients receive every update

## Testing
- curl -s -D - -X POST http://127.0.0.1:8080/analyzeTurns -H 'Content-Type: application/json' -d '{"moves":["B D4"]}'

------
https://chatgpt.com/codex/tasks/task_e_68d2cec24e4c83248d3aeac03471ea4a