### PR TITLE
Ensure run script exports image tag

### DIFF
--- a/scripts/03_run.sh
+++ b/scripts/03_run.sh
@@ -10,6 +10,12 @@ if [ -f .env ]; then
   set +a
 fi
 
+GIT_SHA="${GIT_SHA:-$(git rev-parse --short HEAD 2>/dev/null || true)}"
+if [[ -z "${GIT_SHA}" ]]; then
+  GIT_SHA="local"
+fi
+export GIT_SHA
+
 PORT="${PORT:-2388}"
 HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-180}"
 
@@ -18,7 +24,7 @@ if ! command -v curl >/dev/null 2>&1; then
   exit 1
 fi
 
-docker compose up -d
+docker compose up --build -d
 
 deadline=$((SECONDS + HEALTH_TIMEOUT))
 


### PR DESCRIPTION
## Summary
- compute and export GIT_SHA in scripts/03_run.sh just like the build script so docker compose resolves the freshly built tag
- invoke docker compose up with --build so rerunning the run script also refreshes the tagged image

## Testing
- `./scripts/02_build.sh` *(fails: docker is not available in the execution environment)*
- `./scripts/03_run.sh` *(fails: docker is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2d47b439483249aaa11f78cf298a1