### PR TITLE
Install libzip runtime dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
+    libzip5 \
     python3 \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- add libzip5 to the runtime image so libzip.so.5 is present

## Testing
- ⚠️ `./scripts/02_build.sh` *(fails: docker not installed in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2dd8e8ff48324b4708f4d158dd847