### PR TITLE
Fix CUDA base tag for Ubuntu 24.04; add CI tag check and JSON smoke test

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,0 +1,34 @@
+name: Docker CI
+
+on:
+  push:
+    branches:
+      - "2.2"
+  pull_request:
+    branches:
+      - "2.2"
+
+env:
+  BASE_IMAGE: nvidia/cuda:12.5.1-runtime-ubuntu24.04
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Validate CUDA base image tag
+        run: docker buildx imagetools inspect "${BASE_IMAGE}"
+
+      - name: Validate compose file
+        run: docker compose config
+
+      - name: Build Docker image
+        run: docker compose build
+
+      - name: Smoke test KataGo JSON API
+        run: scripts/04_ci_smoke.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.5.1-cudnn-runtime-ubuntu24.04 AS downloader
+FROM nvidia/cuda:12.5.1-runtime-ubuntu24.04 AS downloader
 
 ARG KATAGO_VER=v1.16.3
 ARG KATAGO_FLAVOR=cuda12.5-cudnn8.9.7-linux-x64
@@ -18,7 +18,7 @@ RUN set -eux; \
   unzip -j katago.zip katago; \
   rm katago.zip
 
-FROM nvidia/cuda:12.5.1-cudnn-runtime-ubuntu24.04
+FROM nvidia/cuda:12.5.1-runtime-ubuntu24.04
 
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # KataGo JSON Analysis Service (2.1)
 
 Dockerized KataGo JSON analysis server tuned for Ubuntu 24.04 hosts with NVIDIA GPUs. The runtime image is based on
-`nvidia/cuda:12.5.1-cudnn-runtime-ubuntu24.04`, downloads the official CUDA 12.5 build of KataGo v1.16.3, and exposes the
+`nvidia/cuda:12.5.1-runtime-ubuntu24.04`, downloads the official CUDA 12.5 build of KataGo v1.16.3, and exposes the
 JSON API on port 2388.
 
 ## What's new in 2.1
@@ -26,7 +26,7 @@ JSON API on port 2388.
 cd KataGo
 ./scripts/00_setup_dirs.sh            # creates config/ and models/; copies config/analysis.cfg if missing
 ./scripts/01_get_model.sh              # downloads the newest kata1 network and links models/latest.bin.gz
-./scripts/02_build.sh                  # builds katago-json:${GIT_SHA:-local}
+./scripts/02_build.sh                  # builds katago-json:${GIT_SHA_SHORT:-local}
 ./scripts/03_run.sh                    # launches the JSON analysis service and waits for health
 curl -fsS http://127.0.0.1:2388 \
   -H 'Content-Type: application/json' \
@@ -47,9 +47,14 @@ and indicate the GPU-enabled analysis service is ready.
 
 ## Compose details
 
-`compose.yaml` builds the image locally (`katago-json:${GIT_SHA:-local}`), publishes port `2388`, mounts the configuration and
-models directories read-only, and reserves all NVIDIA GPUs using the Compose `deploy.resources.reservations.devices` stanza. The
+`docker-compose.yml` builds the image locally (`katago-json:${GIT_SHA_SHORT:-local}`), publishes port `2388`, mounts the configuration and
+models directories read-only, and reserves all NVIDIA GPUs using the Compose `deploy.resources.reservations.devices` stanza so the
 container healthcheck posts `query_version` to the JSON endpoint to verify readiness.
+
+## Troubleshooting
+
+- If the Docker build fails immediately at the `FROM` instruction, verify that `nvidia/cuda:12.5.1-runtime-ubuntu24.04` still
+  exists on Docker Hub and adjust the tag if NVIDIA republishes it under a different name.
 
 ## References
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile
-    image: katago-json:${GIT_SHA:-local}
+    image: katago-json:${GIT_SHA_SHORT:-local}
     environment:
       PORT: "${PORT:-2388}"
       KATAGO_CONFIG: "${KATAGO_CONFIG:-/config/analysis.cfg}"
@@ -18,8 +18,8 @@ services:
         reservations:
           devices:
             - driver: nvidia
-              count: "all"
-              capabilities: ["gpu"]
+              count: all
+              capabilities: [gpu]
     healthcheck:
       test:
         - CMD-SHELL

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,15 @@
 set -euo pipefail
 
 MODEL="${KATAGO_MODEL:-/models/latest.bin.gz}"
-CFG="${KATAGO_CONFIG:-/config/analysis.cfg}"
+if [[ "${KATAGO_CONFIG+x}" == "x" ]]; then
+  if [[ -z "${KATAGO_CONFIG}" ]]; then
+    echo "KATAGO_CONFIG is set but empty; provide a path to a configuration file." >&2
+    exit 1
+  fi
+  CFG="${KATAGO_CONFIG}"
+else
+  CFG="/opt/katago/analysis.cfg"
+fi
 PORT="${PORT:-2388}"
 LISTEN_ADDR="${KATAGO_LISTEN:-0.0.0.0}"
 
@@ -39,11 +47,6 @@ if [[ -n "${KATAGO_ANALYSIS_THREADS:-}" ]]; then
   CONFIG_OVERRIDES+=("numAnalysisThreads=${KATAGO_ANALYSIS_THREADS}")
 fi
 
-if [[ -z "${CFG}" ]]; then
-  echo "No KataGo analysis configuration path provided via KATAGO_CONFIG." >&2
-  exit 1
-fi
-
 if [[ ! -f "${CFG}" ]]; then
   echo "Config not found at ${CFG}" >&2
   ls -l "$(dirname "${CFG}")" || true
@@ -63,14 +66,15 @@ fi
 
 REAL_MODEL="$(readlink -f "$MODEL")"
 REAL_CFG="$(readlink -f "$CFG")"
+echo "Using KataGo analysis config: ${REAL_CFG}" >&2
 
 if [[ "${REAL_MODEL}" != /models/* ]]; then
   echo "Model file must live under /models. Found: ${REAL_MODEL}" >&2
   exit 1
 fi
 
-if [[ "${REAL_CFG}" != /config/* ]]; then
-  echo "Config file must be under /config. Found: ${REAL_CFG}" >&2
+if [[ "${REAL_CFG}" != /config/* && "${REAL_CFG}" != /opt/katago/* ]]; then
+  echo "Config file must be under /config or /opt/katago. Found: ${REAL_CFG}" >&2
   exit 1
 fi
 

--- a/scripts/02_build.sh
+++ b/scripts/02_build.sh
@@ -3,6 +3,6 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-export GIT_SHA="$(git rev-parse --short HEAD 2>/dev/null || echo local)"
+export GIT_SHA_SHORT="$(git rev-parse --short HEAD 2>/dev/null || echo local)"
 
 docker compose build --no-cache

--- a/scripts/03_run.sh
+++ b/scripts/03_run.sh
@@ -10,7 +10,7 @@ if [ -f .env ]; then
   set +a
 fi
 
-export GIT_SHA="${GIT_SHA:-$(git rev-parse --short HEAD 2>/dev/null || echo local)}"
+export GIT_SHA_SHORT="${GIT_SHA_SHORT:-$(git rev-parse --short HEAD 2>/dev/null || echo local)}"
 
 PORT="${PORT:-2388}"
 HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-180}"

--- a/scripts/04_ci_smoke.sh
+++ b/scripts/04_ci_smoke.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cleanup() {
+  docker compose down -v
+}
+trap cleanup EXIT
+
+payload='{"id":"ping","action":"query_version"}'
+
+# Rebuild image without cache to ensure Dockerfile changes are respected
+docker compose build --no-cache
+
+docker compose up -d
+
+endpoint="http://127.0.0.1:2388"
+start_time=$(date +%s)
+
+while true; do
+  if curl -fsS "${endpoint}" \
+    -H 'Content-Type: application/json' \
+    -d "${payload}" >/dev/null; then
+    break
+  fi
+
+  if (( $(date +%s) - start_time >= 60 )); then
+    echo "KataGo JSON API did not become ready within 60 seconds" >&2
+    docker compose logs --no-color katago | tail -n 200
+    exit 1
+  fi
+
+  sleep 2
+done
+
+echo "KataGo JSON API responded successfully"


### PR DESCRIPTION
## Summary
Switch the Docker runtime to a CUDA 12.5.1 runtime base that exists for Ubuntu 24.04, tighten the Compose workflow, and wire up CI coverage so future tag regressions are caught immediately while the JSON API is smoke-tested.

## Changes
- Pin both Dockerfile stages to `nvidia/cuda:12.5.1-runtime-ubuntu24.04`.
- Update Compose to build locally with a short git SHA tag and request all NVIDIA GPUs; refresh helper scripts to match.
- Let the entrypoint respect `KATAGO_CONFIG`, logging the resolved path with a fallback to `/opt/katago/analysis.cfg`.
- Add a smoke-test script and GitHub Actions workflow that validates the base image tag, Compose config, and KataGo JSON API.
- Document the CUDA base tag, Compose GPU reservation, and troubleshooting tips in the README.

## How to test
```sh
docker compose build
scripts/04_ci_smoke.sh
```

------
https://chatgpt.com/codex/tasks/task_e_68d2f0293f988324ba9c6a1f422ebf32