### PR TITLE
Update Docker runtime to install libzip4t64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
-    libzip5 \
+    libzip4t64 \
     python3 \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- replace the runtime image's libzip5 dependency with libzip4t64 to match Ubuntu Noble packages

## Testing
- docker compose build *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d2f2fd90048324b5a692203d3a0f1a