### PR TITLE
Native runner for Ubuntu 25.04: de-AppImage install, user service, CI selftest

### DIFF
--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -1,0 +1,39 @@
+name: Native CI
+
+on:
+  push:
+    branches: ["2.2"]
+  pull_request:
+    branches: ["2.2"]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+      - name: Shellcheck scripts
+        run: |
+          set -euo pipefail
+          mapfile -t scripts_to_check < <(find scripts -name '*.sh' -type f)
+          if [ "${#scripts_to_check[@]}" -gt 0 ]; then
+            shellcheck "${scripts_to_check[@]}"
+          fi
+
+  selftest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Quickstart setup
+        run: |
+          set -euo pipefail
+          ./scripts/00_setup_dirs.sh
+          ./scripts/01_get_model.sh
+          ./scripts/native_install_plucky.sh
+      - name: Serve self-test
+        run: ./serve.py --selftest

--- a/README.md
+++ b/README.md
@@ -1,64 +1,67 @@
-# KataGo JSON Analysis Service (2.1)
+# KataGo JSON Analysis Service (2.2)
 
-Dockerized KataGo JSON analysis server tuned for Ubuntu 24.04 hosts with NVIDIA GPUs. The runtime image is based on
-`nvidia/cuda:12.5.1-runtime-ubuntu24.04`, downloads the official CUDA 12.5 build of KataGo v1.16.3, and exposes the
-JSON API on port 2388.
+Native KataGo JSON analysis server for Ubuntu 25.04 "Plucky Puffin" hosts with NVIDIA GPUs. The helper scripts download the
+official CUDA 12.5 AppImage for KataGo v1.16.3, extract it once to avoid FUSE at runtime, and expose the familiar HTTP JSON API on
+port 2388.
 
-## What's new in 2.1
+## What's new in 2.2
 
-- Local-first Docker Compose workflow that always builds the image from source before running.
-- Host-mounted configuration respected via `${KATAGO_CONFIG:-/config/analysis.cfg}` so local edits take effect immediately.
-- Compose GPU reservation stanza requests all NVIDIA GPUs using the standard `deploy.resources.reservations.devices` block.
-- Helper scripts are idempotent and safe to re-run; they create directories, refresh models, rebuild images, and verify the
-  JSON endpoint automatically.
+- Native runner: `serve.py` keeps a persistent KataGo analysis subprocess without Docker.
+- Idempotent installer: `scripts/native_install_plucky.sh` fetches v1.16.3, extracts the AppImage, and verifies the binary.
+- Systemd integration: `systemd/user/katago-json.service` and `scripts/native_enable_service.sh` manage the JSON endpoint as a
+  user service.
+- Docker workflow is now deprecated in favor of the native runner for Ubuntu 25.04.
 
 ## Prerequisites
 
-- [Docker](https://docs.docker.com/get-docker/)
-- [Docker Compose v2](https://docs.docker.com/compose/install/)
-- NVIDIA GPU driver compatible with CUDA 12.5 (for example, driver 550 or newer)
-- [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)
-- Enable GPU access for Compose per Docker's guidance: [Use GPUs with Docker Compose](https://docs.docker.com/compose/gpu-support/)
+- Ubuntu 25.04 with Python 3.12+
+- NVIDIA GPU driver compatible with CUDA 12.5 (driver 550 or newer is recommended)
+- `curl`, `unzip`, and `systemd --user` support
 
-## Quickstart
+## Quickstart (Native on Ubuntu 25.04)
 
 ```bash
-cd KataGo
-./scripts/00_setup_dirs.sh            # creates config/ and models/; copies config/analysis.cfg if missing
-./scripts/01_get_model.sh              # downloads the newest kata1 network and links models/latest.bin.gz
-./scripts/02_build.sh                  # builds katago-json:${GIT_SHA_SHORT:-local}
-./scripts/03_run.sh                    # launches the JSON analysis service and waits for health
-curl -fsS http://127.0.0.1:2388 \
-  -H 'Content-Type: application/json' \
-  -d '{"id":"ping","action":"query_version"}' | python3 -m json.tool
+git clone -b 2.2 https://github.com/MadManofEurope/KataGo && cd KataGo
+./scripts/00_setup_dirs.sh
+./scripts/01_get_model.sh
+./scripts/native_install_plucky.sh
+./scripts/native_run.sh
 ```
 
-The final `curl` command is the same request used by the container healthcheck. Successful responses include the KataGo version
-and indicate the GPU-enabled analysis service is ready.
+The runner binds to `127.0.0.1:2388` by default. Adjust `KATAGO_CONFIG` to point at a custom configuration file if desired.
+
+### Health check
+
+```bash
+curl -fsS http://127.0.0.1:2388 \
+  -H 'Content-Type: application/json' \
+  -d '{"id":"ping","action":"query_version"}'
+```
+
+Successful responses echo the installed KataGo version. To verify the binary without launching the server, run `./serve.py --selftest`.
+
+### Optional: enable as a user service
+
+```bash
+./scripts/native_enable_service.sh
+systemctl --user status katago-json.service
+```
+
+The service runs from `~/KataGo`, restarts automatically, and can be disabled with `systemctl --user disable --now katago-json.service`.
 
 ## Configuration and models
 
-- `config/analysis.cfg` is mounted read-only into the container. `scripts/00_setup_dirs.sh` seeds it from
-  `config/analysis.cfg.template` if the file is missing. Edit it locally to adjust analysis parameters. The container also forces
-  `allowResignation=false` via `-override-config` so KataGo never resigns during analysis sessions.
-- `KATAGO_CONFIG` defaults to `/config/analysis.cfg`; override it in `.env` if you mount the config elsewhere.
-- Models in `models/` are mounted read-only. The runtime expects `/models/latest.bin.gz`; the helper script maintains this symlink so
-  you can keep multiple networks side by side.
+- `config/analysis.cfg` is seeded by `scripts/00_setup_dirs.sh` from `config/analysis.cfg.template`. Update it to suit your analysis
+  requirements.
+- `models/latest.bin.gz` is managed by `scripts/01_get_model.sh`, which downloads the latest kata1 network and refreshes the symlink.
+- Set `KATAGO_CONFIG` before starting the runner to override the default configuration path.
 
-## Compose details
+## Why extract the AppImage?
 
-`docker-compose.yml` builds the image locally (`katago-json:${GIT_SHA_SHORT:-local}`), publishes port `2388`, mounts the configuration and
-models directories read-only, and reserves all NVIDIA GPUs using the Compose `deploy.resources.reservations.devices` stanza so the
-container healthcheck posts `query_version` to the JSON endpoint to verify readiness.
-
-## Troubleshooting
-
-- If the Docker build fails immediately at the `FROM` instruction, verify that `nvidia/cuda:12.5.1-runtime-ubuntu24.04` still
-  exists on Docker Hub and adjust the tag if NVIDIA republishes it under a different name.
+KataGo's Linux releases ship as AppImages. Extracting the AppImage at install time removes the runtime FUSE requirement, so the
+native runner works on minimal Ubuntu installations without extra kernel modules or elevated privileges.
 
 ## References
 
 - [KataGo releases](https://github.com/lightvector/KataGo/releases)
-- [CUDA 12.5.1 runtime Ubuntu 24.04 tag](https://hub.docker.com/r/nvidia/cuda/tags?name=12.5.1-runtime-ubuntu24.04)
-- [Docker: Use GPUs with Compose](https://docs.docker.com/compose/gpu-support/)
-- [NVIDIA Container Toolkit install guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)
+- [Ubuntu 25.04 (Plucky Puffin)](https://discourse.ubuntu.com/t/plucky-puffin-release-notes/)

--- a/scripts/native_enable_service.sh
+++ b/scripts/native_enable_service.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SERVICE_SRC="${ROOT_DIR}/systemd/user/katago-json.service"
+SERVICE_DEST="${HOME}/.config/systemd/user/katago-json.service"
+
+if [ ! -f "${SERVICE_SRC}" ]; then
+  echo "Service template missing at ${SERVICE_SRC}." >&2
+  exit 1
+fi
+
+mkdir -p "${HOME}/.config/systemd/user"
+cp "${SERVICE_SRC}" "${SERVICE_DEST}"
+
+systemctl --user daemon-reload
+systemctl --user enable --now katago-json.service
+
+echo "Enabled katago-json.service as a user service."

--- a/scripts/native_install_plucky.sh
+++ b/scripts/native_install_plucky.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+BIN_DIR="${ROOT_DIR}/.bin"
+VENV_DIR="${ROOT_DIR}/.venv"
+KATAGO_BIN="${BIN_DIR}/katago"
+APPIMAGE_PATH="${BIN_DIR}/katago.AppImage"
+ZIP_PATH="${BIN_DIR}/katago.zip"
+MODEL_PATH="${ROOT_DIR}/models/latest.bin.gz"
+CONFIG_PATH="${ROOT_DIR}/config/analysis.cfg"
+RELEASE_URL="https://github.com/lightvector/KataGo/releases/download/v1.16.3/katago-v1.16.3-cuda12.5-cudnn8.9.7-linux-x64.zip"
+
+mkdir -p "${BIN_DIR}" "${VENV_DIR}"
+
+if [ ! -f "${CONFIG_PATH}" ]; then
+  echo "Missing ${CONFIG_PATH}. Run ./scripts/00_setup_dirs.sh to create it." >&2
+  exit 1
+fi
+
+if [ ! -f "${MODEL_PATH}" ]; then
+  echo "Missing ${MODEL_PATH}. Run ./scripts/01_get_model.sh to download a network." >&2
+  exit 1
+fi
+
+if [ -x "${KATAGO_BIN}" ]; then
+  if "${KATAGO_BIN}" --version >/dev/null 2>&1; then
+    echo "KataGo already installed at ${KATAGO_BIN}."
+    exit 0
+  else
+    echo "Existing ${KATAGO_BIN} is not functional. Reinstalling." >&2
+    rm -f "${KATAGO_BIN}"
+  fi
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "curl is required to download KataGo." >&2
+  exit 1
+fi
+
+if ! command -v unzip >/dev/null 2>&1; then
+  echo "unzip is required to extract KataGo." >&2
+  exit 1
+fi
+
+tmp_zip="${ZIP_PATH}.tmp"
+
+if [ ! -f "${ZIP_PATH}" ]; then
+  echo "Downloading KataGo v1.16.3 CUDA12.5 AppImage..." >&2
+  curl -fL "${RELEASE_URL}" -o "${tmp_zip}"
+  mv -f "${tmp_zip}" "${ZIP_PATH}"
+else
+  echo "Using cached ${ZIP_PATH}." >&2
+fi
+
+tmp_extract_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_extract_dir}"' EXIT
+
+unzip -o "${ZIP_PATH}" -d "${tmp_extract_dir}" >&2
+
+extracted_appimage="${tmp_extract_dir}/katago"
+if [ ! -f "${extracted_appimage}" ]; then
+  echo "Expected katago AppImage not found after extraction." >&2
+  exit 1
+fi
+
+mv -f "${extracted_appimage}" "${APPIMAGE_PATH}"
+chmod +x "${APPIMAGE_PATH}"
+
+(
+  cd "${BIN_DIR}"
+  echo "Extracting KataGo AppImage to avoid FUSE dependency..." >&2
+  "${APPIMAGE_PATH}" --appimage-extract || true
+  if [ -d "squashfs-root" ]; then
+    rm -rf katago.AppDir
+    mv squashfs-root katago.AppDir
+    cat > "${KATAGO_BIN}" <<'WRAPPER'
+#!/usr/bin/env bash
+set -euo pipefail
+DIR="$(cd "$(dirname "$0")" && pwd)"
+exec "${DIR}/katago.AppDir/AppRun" "$@"
+WRAPPER
+    chmod +x "${KATAGO_BIN}"
+  else
+    echo "AppImage extraction did not produce squashfs-root." >&2
+    exit 1
+  fi
+)
+
+if ! "${KATAGO_BIN}" --version >/dev/null 2>&1; then
+  echo "KataGo binary at ${KATAGO_BIN} failed to execute." >&2
+  if command -v ldd >/dev/null 2>&1; then
+    missing_libs=$(ldd "${BIN_DIR}/katago.AppDir/usr/bin/katago" | awk '/not found/ {print $1}')
+    if [ -n "${missing_libs}" ]; then
+      echo "Missing shared libraries: ${missing_libs}" >&2
+    fi
+  fi
+  echo "Ensure the CUDA 12.5 runtime (including libcublas) is available and retry." >&2
+  exit 1
+fi
+
+echo "KataGo v1.16.3 installed at ${KATAGO_BIN}."

--- a/scripts/native_run.sh
+++ b/scripts/native_run.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+KATAGO_BIN="${ROOT_DIR}/.bin/katago"
+MODEL_PATH="${ROOT_DIR}/models/latest.bin.gz"
+CONFIG_PATH="${KATAGO_CONFIG:-${ROOT_DIR}/config/analysis.cfg}"
+HOST="127.0.0.1"
+PORT="2388"
+
+if [ ! -x "${KATAGO_BIN}" ]; then
+  echo "KataGo binary not found at ${KATAGO_BIN}. Run ./scripts/native_install_plucky.sh first." >&2
+  exit 1
+fi
+
+if [ ! -f "${MODEL_PATH}" ]; then
+  echo "Model file ${MODEL_PATH} is missing. Run ./scripts/01_get_model.sh." >&2
+  exit 1
+fi
+
+if [ ! -f "${CONFIG_PATH}" ]; then
+  echo "Config file ${CONFIG_PATH} is missing. Set KATAGO_CONFIG or run ./scripts/00_setup_dirs.sh." >&2
+  exit 1
+fi
+
+echo "Using config: ${CONFIG_PATH}"
+
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+set +e
+"${PYTHON_BIN}" "${ROOT_DIR}/serve.py" \
+  --host "${HOST}" \
+  --port "${PORT}" \
+  --katago "${KATAGO_BIN}" \
+  --model "${MODEL_PATH}" \
+  --config "${CONFIG_PATH}" &
+SERVER_PID=$!
+set -e
+
+cleanup() {
+  if kill -0 "${SERVER_PID}" >/dev/null 2>&1; then
+    kill "${SERVER_PID}"
+    wait "${SERVER_PID}" || true
+  fi
+}
+
+trap cleanup INT TERM EXIT
+wait "${SERVER_PID}"

--- a/serve.py
+++ b/serve.py
@@ -1,55 +1,60 @@
 #!/usr/bin/env python3
-"""Expose KataGo's JSON analysis engine over TCP/HTTP."""
+"""Expose KataGo's JSON analysis engine over HTTP."""
+
+from __future__ import annotations
 
 import argparse
 import json
-import logging
-import socketserver
-import subprocess
+import os
+import signal
 import sys
 import threading
-from typing import List
-
-LOG = logging.getLogger("katago-proxy")
-
-
-def build_command(args: argparse.Namespace) -> List[str]:
-    cmd: List[str] = [
-        args.katago,
-        "analysis",
-        "-model",
-        args.model,
-        "-config",
-        args.config,
-    ]
-    for override in args.override_config:
-        cmd.extend(["-override-config", override])
-    return cmd
+from dataclasses import dataclass
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Dict, Optional
+import subprocess
 
 
-class ThreadedTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
-    allow_reuse_address = True
+@dataclass
+class EngineConfig:
+    katago: Path
+    model: Path
+    config: Path
 
-    def __init__(self, server_address, handler_class, base_cmd: List[str]):
-        super().__init__(server_address, handler_class)
-        self.base_cmd = list(base_cmd)
 
+class KataGoEngine:
+    """Manage a persistent KataGo analysis subprocess."""
 
-class KataGoRequestHandler(socketserver.StreamRequestHandler):
-    def handle(self) -> None:  # type: ignore[override]
-        try:
-            # Peek without consuming to decide if this is HTTP or raw JSON.
-            initial = self.rfile.peek(4)
-        except AttributeError:
-            initial = self.rfile.read(0)
-        if initial and initial.startswith((b"POST", b"GET")):
-            self._handle_http()
-        else:
-            self._handle_stream()
+    def __init__(self, cfg: EngineConfig) -> None:
+        self._cfg = cfg
+        self._lock = threading.Lock()
+        self._proc = self._launch()
 
-    def _spawn_katago(self) -> subprocess.Popen:
-        cmd = list(self.server.base_cmd)
-        LOG.debug("Launching KataGo: %s", " ".join(cmd))
+    def _launch(self) -> subprocess.Popen:
+        if not self._cfg.katago.exists():
+            raise FileNotFoundError(
+                f"KataGo binary not found at {self._cfg.katago}. Run native_install_plucky.sh."
+            )
+        if not os.access(self._cfg.katago, os.X_OK):
+            raise PermissionError(f"KataGo binary at {self._cfg.katago} is not executable.")
+        if not self._cfg.model.exists():
+            raise FileNotFoundError(
+                f"Model file not found at {self._cfg.model}. Run scripts/01_get_model.sh."
+            )
+        if not self._cfg.config.exists():
+            raise FileNotFoundError(
+                f"Config file not found at {self._cfg.config}. Run scripts/00_setup_dirs.sh."
+            )
+        cmd = [
+            str(self._cfg.katago),
+            "analysis",
+            "-model",
+            str(self._cfg.model),
+            "-config",
+            str(self._cfg.config),
+        ]
         return subprocess.Popen(
             cmd,
             stdin=subprocess.PIPE,
@@ -59,163 +64,177 @@ class KataGoRequestHandler(socketserver.StreamRequestHandler):
             bufsize=1,
         )
 
-    def _handle_stream(self) -> None:
-        proc = self._spawn_katago()
-
-        def forward_stdout() -> None:
-            assert proc.stdout is not None
-            while True:
-                line = proc.stdout.readline()
-                if not line:
-                    break
-                try:
-                    self.wfile.write(line.encode("utf-8"))
-                    self.wfile.flush()
-                except BrokenPipeError:
-                    break
-
-        thread = threading.Thread(target=forward_stdout, daemon=True)
-        thread.start()
-
+    def terminate(self) -> None:
+        proc = self._proc
+        if proc.poll() is not None:
+            return
+        proc.terminate()
         try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+
+    def query(self, payload: Dict[str, object]) -> str:
+        text = json.dumps(payload, separators=(",", ":")) + "\n"
+        with self._lock:
+            proc = self._proc
+            if proc.poll() is not None:
+                raise RuntimeError("KataGo engine has exited unexpectedly.")
             assert proc.stdin is not None
-            while True:
-                data = self.rfile.readline()
-                if not data:
-                    break
-                proc.stdin.write(data.decode("utf-8", "ignore"))
-                proc.stdin.flush()
-        finally:
-            try:
-                proc.stdin.close()  # type: ignore[call-arg]
-            except Exception:
-                pass
-            proc.wait(timeout=5)
-
-    def _handle_http(self) -> None:
-        request_line = self.rfile.readline().decode("latin1", "ignore")
-        parts = request_line.strip().split()
-        if len(parts) != 3:
-            self._send_http_error(400, "Bad Request")
-            return
-        method, _path, _version = parts
-        if method.upper() != "POST":
-            self._send_http_error(405, "Method Not Allowed")
-            return
-
-        headers = {}
-        while True:
-            line = self.rfile.readline()
-            if line in (b"\r\n", b"\n", b""):
-                break
-            key, _, value = line.decode("latin1", "ignore").partition(":")
-            headers[key.strip().lower()] = value.strip()
-
-        try:
-            length = int(headers.get("content-length", "0"))
-        except ValueError:
-            self._send_http_error(411, "Length Required")
-            return
-
-        body = self.rfile.read(length) if length else b""
-        if not body:
-            self._send_http_error(400, "Empty body")
-            return
-
-        try:
-            json.loads(body.decode("utf-8"))
-        except json.JSONDecodeError:
-            self._send_http_error(400, "Body must be valid JSON")
-            return
-
-        proc = self._spawn_katago()
-        assert proc.stdin is not None and proc.stdout is not None
-
-        try:
-            text_body = body.decode("utf-8")
-            if not text_body.endswith("\n"):
-                text_body += "\n"
-            proc.stdin.write(text_body)
+            assert proc.stdout is not None
+            proc.stdin.write(text)
             proc.stdin.flush()
-            try:
-                proc.stdin.close()  # type: ignore[call-arg]
-            except Exception:
-                pass
-
-            responses: List[str] = []
+            request_id = payload.get("id") if isinstance(payload, dict) else None
+            lines: list[str] = []
             while True:
                 line = proc.stdout.readline()
                 if not line:
-                    break
-                responses.append(line)
-        finally:
-            proc.wait(timeout=5)
+                    raise RuntimeError("KataGo produced no response and may have exited.")
+                lines.append(line)
+                try:
+                    parsed = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(parsed, dict):
+                    if "error" in parsed:
+                        break
+                    parsed_id = parsed.get("id")
+                    is_alive = parsed.get("isAlive")
+                    if request_id is None:
+                        if is_alive is False:
+                            break
+                        if "isAlive" not in parsed:
+                            break
+                    else:
+                        if parsed_id == request_id and is_alive is False:
+                            break
+                        if parsed_id == request_id and "isAlive" not in parsed:
+                            break
+            return "".join(lines)
 
-        if not responses:
-            self._send_http_error(502, "No response from KataGo")
+
+class KataGoRequestHandler(BaseHTTPRequestHandler):
+    engine: KataGoEngine  # Injected at server startup.
+
+    def do_POST(self) -> None:  # noqa: N802 - inherited
+        if self.path != "/query":
+            self._send_error(HTTPStatus.NOT_FOUND, "Only /query is supported")
             return
-
-        response_text = "".join(responses)
-        payload = response_text.encode("utf-8")
-        headers_out = (
-            f"HTTP/1.1 200 OK\r\n"
-            f"Content-Type: application/json\r\n"
-            f"Content-Length: {len(payload)}\r\n"
-            f"Connection: close\r\n\r\n"
-        ).encode("ascii")
-        self.wfile.write(headers_out)
-        self.wfile.write(payload)
-        self.wfile.flush()
-
-    def _send_http_error(self, status: int, message: str) -> None:
-        body = json.dumps({"error": message, "status": status})
-        payload = body.encode("utf-8")
-        headers_out = (
-            f"HTTP/1.1 {status} {message}\r\n"
-            f"Content-Type: application/json\r\n"
-            f"Content-Length: {len(payload)}\r\n"
-            f"Connection: close\r\n\r\n"
-        ).encode("ascii")
+        content_length = self.headers.get("Content-Length")
+        if content_length is None:
+            self._send_error(HTTPStatus.LENGTH_REQUIRED, "Missing Content-Length header")
+            return
         try:
-            self.wfile.write(headers_out)
-            self.wfile.write(payload)
-            self.wfile.flush()
-        except BrokenPipeError:
-            pass
+            length = int(content_length)
+        except ValueError:
+            self._send_error(HTTPStatus.BAD_REQUEST, "Invalid Content-Length header")
+            return
+        body = self.rfile.read(length)
+        if not body:
+            self._send_error(HTTPStatus.BAD_REQUEST, "Empty request body")
+            return
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except json.JSONDecodeError:
+            self._send_error(HTTPStatus.BAD_REQUEST, "Body must be valid JSON")
+            return
+        if not isinstance(payload, dict):
+            self._send_error(HTTPStatus.BAD_REQUEST, "Body must be a JSON object")
+            return
+        try:
+            response_text = self.engine.query(payload)
+        except FileNotFoundError as exc:
+            self._send_error(HTTPStatus.SERVICE_UNAVAILABLE, str(exc))
+            return
+        except Exception as exc:  # noqa: BLE001 - surface engine failures
+            self._send_error(HTTPStatus.BAD_GATEWAY, f"KataGo query failed: {exc}")
+            return
+        response_bytes = response_text.encode("utf-8")
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(response_bytes)))
+        self.end_headers()
+        self.wfile.write(response_bytes)
+
+    def do_GET(self) -> None:  # noqa: N802 - inherited
+        self._send_error(HTTPStatus.METHOD_NOT_ALLOWED, "Use POST /query")
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A003 - match BaseHTTPRequestHandler
+        sys.stderr.write("[serve.py] " + (format % args) + "\n")
+
+    def _send_error(self, status: HTTPStatus, message: str) -> None:
+        body = json.dumps({"error": message, "status": status.value})
+        data = body.encode("utf-8")
+        self.send_response(status.value)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
 
 
-def main() -> None:
+def parse_args() -> argparse.Namespace:
+    repo_root = Path(__file__).resolve().parent
+    default_katago = repo_root / ".bin/katago"
+    default_model = repo_root / "models/latest.bin.gz"
+    default_config = Path(os.environ.get("KATAGO_CONFIG", repo_root / "config/analysis.cfg"))
+
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--listen", default="0.0.0.0")
+    parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=2388)
-    parser.add_argument("--katago", required=True)
-    parser.add_argument("--model", required=True)
-    parser.add_argument("--config", required=True)
-    parser.add_argument(
-        "--override-config",
-        action="append",
-        default=[],
-        help="Additional -override-config entries passed to KataGo",
-    )
-    parser.add_argument(
-        "--log-level",
-        default="INFO",
-        choices=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
-    )
-    args = parser.parse_args()
+    parser.add_argument("--katago", type=Path, default=default_katago)
+    parser.add_argument("--model", type=Path, default=default_model)
+    parser.add_argument("--config", type=Path, default=default_config)
+    parser.add_argument("--selftest", action="store_true", help="Run a query_version check and exit")
+    return parser.parse_args()
 
-    logging.basicConfig(level=getattr(logging, args.log_level))
-    base_cmd = build_command(args)
 
-    server = ThreadedTCPServer((args.listen, args.port), KataGoRequestHandler, base_cmd)
-    LOG.info("Serving KataGo on %s:%s", args.listen, args.port)
+def run_server(args: argparse.Namespace, engine: KataGoEngine) -> None:
+    handler_cls = KataGoRequestHandler
+    handler_cls.engine = engine
+    server = ThreadingHTTPServer((args.host, args.port), handler_cls)
+    server.daemon_threads = True
+
+    def shutdown(_signum: int, _frame: Optional[object]) -> None:
+        server.shutdown()
+
+    signal.signal(signal.SIGINT, shutdown)
+    signal.signal(signal.SIGTERM, shutdown)
     try:
         server.serve_forever()
-    except KeyboardInterrupt:
-        LOG.info("Shutting down KataGo proxy")
     finally:
+        engine.terminate()
         server.server_close()
 
 
+def run_selftest(engine: KataGoEngine) -> int:
+    try:
+        response_text = engine.query({"id": "selftest", "action": "query_version"})
+    except Exception as exc:  # noqa: BLE001
+        print(f"Selftest failed: {exc}", file=sys.stderr)
+        engine.terminate()
+        return 1
+    engine.terminate()
+    print(response_text.strip())
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+    cfg = EngineConfig(katago=args.katago, model=args.model, config=args.config)
+    try:
+        engine = KataGoEngine(cfg)
+    except (FileNotFoundError, PermissionError) as exc:
+        print(f"Failed to launch KataGo: {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:  # noqa: BLE001
+        print(f"Failed to launch KataGo: {exc}", file=sys.stderr)
+        return 1
+    if args.selftest:
+        return run_selftest(engine)
+    run_server(args, engine)
+    return 0
+
+
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/systemd/user/katago-json.service
+++ b/systemd/user/katago-json.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=KataGo JSON analysis service
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/KataGo
+ExecStart=%h/KataGo/serve.py
+Restart=always
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary
- add native installation, run, and service enablement scripts that cache the v1.16.3 CUDA AppImage and surface missing CUDA libraries
- replace the Python proxy with a persistent KataGo runner that exposes /query and a --selftest mode for health checks
- provide a user-level systemd unit, native CI workflow, and refreshed README instructions that deprecate Docker in favor of the Ubuntu 25.04 path

## Testing
- ./scripts/00_setup_dirs.sh
- ./scripts/01_get_model.sh
- ./scripts/native_install_plucky.sh *(fails locally: missing CUDA 12.5 libraries)*
- ./serve.py --selftest *(fails locally before install, as expected)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a6f736cc83249743cbb9f950aca2