### PR TITLE
Native bootstrap: fetch model, extract KataGo, generate config; add selftest + CI

### DIFF
--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -1,39 +1,56 @@
-name: Native CI
+name: native-ci
 
 on:
   push:
-    branches: ["2.2"]
+    branches:
+      - 2.2
   pull_request:
-    branches: ["2.2"]
+    branches:
+      - 2.2
 
 jobs:
-  lint:
+  native:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Install shellcheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
-      - name: Shellcheck scripts
-        run: |
-          set -euo pipefail
-          mapfile -t scripts_to_check < <(find scripts -name '*.sh' -type f)
-          if [ "${#scripts_to_check[@]}" -gt 0 ]; then
-            shellcheck "${scripts_to_check[@]}"
-          fi
 
-  selftest:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-      - name: Quickstart setup
+      - name: Shellcheck scripts
+        run: shellcheck scripts/*.sh
+
+      - name: Selftest with mock KataGo
         run: |
+          mkdir -p .bin models config
+          cat > .bin/katago <<'STUB'
+          #!/usr/bin/env bash
           set -euo pipefail
-          ./scripts/00_setup_dirs.sh
-          ./scripts/01_get_model.sh
-          ./scripts/native_install_plucky.sh
-      - name: Serve self-test
-        run: ./serve.py --selftest
+          if [[ "${1:-}" == "--version" ]]; then
+            echo "KataGo mock 1.16.3"
+            exit 0
+          fi
+          if [[ "${1:-}" == "--appimage-extract" ]]; then
+            exit 0
+          fi
+          if [[ "${1:-}" == "analysis" ]]; then
+            # Consume parameters: -model <path> -config <path>
+            shift
+            shift || true
+            shift || true
+            shift || true
+            shift || true
+            while IFS= read -r line; do
+              [[ -z "$line" ]] && continue
+              echo '{"id":"ping","version":"mock","isAlive":false}'
+            done
+            exit 0
+          fi
+          echo "Unexpected invocation: $*" >&2
+          exit 1
+STUB
+          chmod +x .bin/katago
+          printf 'cfg' > config/analysis.cfg
+          printf 'model' > models/latest.bin.gz
+          python3 serve.py --selftest --katago ./.bin/katago --model ./models/latest.bin.gz --config ./config/analysis.cfg

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ port 2388.
 ## What's new in 2.2
 
 - Native runner: `serve.py` keeps a persistent KataGo analysis subprocess without Docker.
-- Idempotent installer: `scripts/native_install_plucky.sh` fetches v1.16.3, extracts the AppImage, and verifies the binary.
+- Idempotent installer: `scripts/native_install.sh` fetches v1.16.3, extracts the AppImage, and verifies the binary.
 - Systemd integration: `systemd/user/katago-json.service` and `scripts/native_enable_service.sh` manage the JSON endpoint as a
   user service.
 - Docker workflow is now deprecated in favor of the native runner for Ubuntu 25.04.
@@ -22,13 +22,12 @@ port 2388.
 
 ```bash
 git clone -b 2.2 https://github.com/MadManofEurope/KataGo && cd KataGo
-./scripts/00_setup_dirs.sh
+./scripts/native_install.sh
 ./scripts/01_get_model.sh
-./scripts/native_install_plucky.sh
 ./scripts/native_run.sh
 ```
 
-The runner binds to `127.0.0.1:2388` by default. Adjust `KATAGO_CONFIG` to point at a custom configuration file if desired.
+`native_install.sh` prepares `.bin/katago`, `config/analysis.cfg`, and supporting directories. The runner binds to `127.0.0.1:2388` by default.
 
 ### Health check
 
@@ -38,7 +37,11 @@ curl -fsS http://127.0.0.1:2388 \
   -d '{"id":"ping","action":"query_version"}'
 ```
 
-Successful responses echo the installed KataGo version. To verify the binary without launching the server, run `./serve.py --selftest`.
+Successful responses echo the installed KataGo version. To verify the binary without launching the server, run:
+
+```bash
+python3 serve.py --selftest
+```
 
 ### Optional: enable as a user service
 
@@ -51,7 +54,7 @@ The service runs from `~/KataGo`, restarts automatically, and can be disabled wi
 
 ## Configuration and models
 
-- `config/analysis.cfg` is seeded by `scripts/00_setup_dirs.sh` from `config/analysis.cfg.template`. Update it to suit your analysis
+- `config/analysis.cfg` is seeded by `scripts/native_install.sh` from `config/analysis.cfg.template`. Update it to suit your analysis
   requirements.
 - `models/latest.bin.gz` is managed by `scripts/01_get_model.sh`, which downloads the latest kata1 network and refreshes the symlink.
 - Set `KATAGO_CONFIG` before starting the runner to override the default configuration path.

--- a/scripts/02_build.sh
+++ b/scripts/02_build.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-export GIT_SHA_SHORT="$(git rev-parse --short HEAD 2>/dev/null || echo local)"
+GIT_SHA_SHORT="$(git rev-parse --short HEAD 2>/dev/null || echo local)"
+export GIT_SHA_SHORT
 
 docker compose build --no-cache

--- a/scripts/native_install.sh
+++ b/scripts/native_install.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+BIN_DIR="${ROOT_DIR}/.bin"
+MODELS_DIR="${ROOT_DIR}/models"
+CONFIG_DIR="${ROOT_DIR}/config"
+CONFIG_TEMPLATE="${CONFIG_DIR}/analysis.cfg.template"
+CONFIG_PATH="${CONFIG_DIR}/analysis.cfg"
+ZIP_URL="https://github.com/lightvector/KataGo/releases/download/v1.16.3/KataGo-v1.16.3-cuda12.5-linux-x64.zip"
+ZIP_PATH="${BIN_DIR}/KataGo-v1.16.3-cuda12.5-linux-x64.zip"
+APPIMAGE_PATH="${BIN_DIR}/katago"
+EXTRACTED_BIN="${BIN_DIR}/katago.bin"
+
+mkdir -p "${BIN_DIR}" "${MODELS_DIR}" "${CONFIG_DIR}"
+
+if [[ -f "${CONFIG_TEMPLATE}" && ! -f "${CONFIG_PATH}" ]]; then
+  cp "${CONFIG_TEMPLATE}" "${CONFIG_PATH}"
+fi
+
+if [[ -x "${APPIMAGE_PATH}" ]] && "${APPIMAGE_PATH}" --version >/dev/null 2>&1; then
+  exit 0
+fi
+
+echo "Installing KataGo v1.16.3 (CUDA12.5) into ${BIN_DIR}" >&2
+
+if [[ ! -f "${ZIP_PATH}" ]]; then
+  tmp_zip="${ZIP_PATH}.tmp"
+  echo "Downloading KataGo release zip..." >&2
+  curl -fL "${ZIP_URL}" -o "${tmp_zip}"
+  mv "${tmp_zip}" "${ZIP_PATH}"
+fi
+
+unzip -o "${ZIP_PATH}" -d "${BIN_DIR}" >/dev/null
+
+appimage_source="$(find "${BIN_DIR}" -maxdepth 1 -type f -name '*.AppImage' | head -n1)"
+if [[ -z "${appimage_source}" ]]; then
+  echo "Failed to locate AppImage after unzip. Contents:" >&2
+  ls -al "${BIN_DIR}" >&2
+  exit 1
+fi
+
+mv -f "${appimage_source}" "${APPIMAGE_PATH}"
+chmod +x "${APPIMAGE_PATH}"
+
+pushd "${ROOT_DIR}" >/dev/null
+"${APPIMAGE_PATH}" --appimage-extract || true
+if [[ -f "squashfs-root/usr/bin/katago" ]]; then
+  mv -f "squashfs-root/usr/bin/katago" "${EXTRACTED_BIN}"
+  chmod +x "${EXTRACTED_BIN}"
+  rm -rf "squashfs-root"
+  ln -sfn "katago.bin" "${APPIMAGE_PATH}"
+fi
+popd >/dev/null
+
+if ! "${APPIMAGE_PATH}" --version >/dev/null 2>&1; then
+  echo "KataGo binary at ${APPIMAGE_PATH} failed to run. Check installation." >&2
+  exit 1
+fi

--- a/scripts/native_run.sh
+++ b/scripts/native_run.sh
@@ -2,30 +2,26 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+INSTALL_SCRIPT="${ROOT_DIR}/scripts/native_install.sh"
 KATAGO_BIN="${ROOT_DIR}/.bin/katago"
 MODEL_PATH="${ROOT_DIR}/models/latest.bin.gz"
 CONFIG_PATH="${KATAGO_CONFIG:-${ROOT_DIR}/config/analysis.cfg}"
 HOST="127.0.0.1"
 PORT="2388"
 
-if [ ! -x "${KATAGO_BIN}" ]; then
-  echo "KataGo binary not found at ${KATAGO_BIN}. Run ./scripts/native_install_plucky.sh first." >&2
-  exit 1
-fi
-
-if [ ! -f "${MODEL_PATH}" ]; then
-  echo "Model file ${MODEL_PATH} is missing. Run ./scripts/01_get_model.sh." >&2
-  exit 1
-fi
-
-if [ ! -f "${CONFIG_PATH}" ]; then
-  echo "Config file ${CONFIG_PATH} is missing. Set KATAGO_CONFIG or run ./scripts/00_setup_dirs.sh." >&2
-  exit 1
-fi
-
-echo "Using config: ${CONFIG_PATH}"
+"${INSTALL_SCRIPT}"
 
 PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+cleanup() {
+  if [[ -n "${SERVER_PID:-}" ]] && kill -0 "${SERVER_PID}" >/dev/null 2>&1; then
+    kill "${SERVER_PID}"
+    wait "${SERVER_PID}" || true
+  fi
+}
+
+trap cleanup INT TERM
+trap 'cleanup; exit' EXIT
 
 set +e
 "${PYTHON_BIN}" "${ROOT_DIR}/serve.py" \
@@ -37,12 +33,4 @@ set +e
 SERVER_PID=$!
 set -e
 
-cleanup() {
-  if kill -0 "${SERVER_PID}" >/dev/null 2>&1; then
-    kill "${SERVER_PID}"
-    wait "${SERVER_PID}" || true
-  fi
-}
-
-trap cleanup INT TERM EXIT
 wait "${SERVER_PID}"

--- a/serve.py
+++ b/serve.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 import signal
+import subprocess
 import sys
 import threading
 from dataclasses import dataclass
@@ -14,7 +15,6 @@ from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Dict, Optional
-import subprocess
 
 
 @dataclass
@@ -33,20 +33,6 @@ class KataGoEngine:
         self._proc = self._launch()
 
     def _launch(self) -> subprocess.Popen:
-        if not self._cfg.katago.exists():
-            raise FileNotFoundError(
-                f"KataGo binary not found at {self._cfg.katago}. Run native_install_plucky.sh."
-            )
-        if not os.access(self._cfg.katago, os.X_OK):
-            raise PermissionError(f"KataGo binary at {self._cfg.katago} is not executable.")
-        if not self._cfg.model.exists():
-            raise FileNotFoundError(
-                f"Model file not found at {self._cfg.model}. Run scripts/01_get_model.sh."
-            )
-        if not self._cfg.config.exists():
-            raise FileNotFoundError(
-                f"Config file not found at {self._cfg.config}. Run scripts/00_setup_dirs.sh."
-            )
         cmd = [
             str(self._cfg.katago),
             "analysis",
@@ -209,19 +195,50 @@ def run_server(args: argparse.Namespace, engine: KataGoEngine) -> None:
 
 def run_selftest(engine: KataGoEngine) -> int:
     try:
-        response_text = engine.query({"id": "selftest", "action": "query_version"})
+        response_text = engine.query({"id": "ping", "action": "query_version"})
+        first_line = next((line for line in response_text.splitlines() if line.strip()), "")
+        if not first_line:
+            raise RuntimeError("KataGo returned an empty response")
+        json.loads(first_line)
     except Exception as exc:  # noqa: BLE001
         print(f"Selftest failed: {exc}", file=sys.stderr)
         engine.terminate()
         return 1
     engine.terminate()
-    print(response_text.strip())
+    print(first_line)
     return 0
+
+
+def validate_environment(katago: Path, model: Path, config: Path) -> bool:
+    errors: list[str] = []
+    if not katago.exists():
+        errors.append(
+            f"Missing KataGo binary at {katago}. Run ./scripts/native_install.sh to install it."
+        )
+    elif not os.access(katago, os.X_OK):
+        errors.append(
+            f"KataGo binary at {katago} is not executable. Re-run ./scripts/native_install.sh."
+        )
+    if not model.exists():
+        errors.append(
+            f"Missing model file at {model}. Run ./scripts/01_get_model.sh after ./scripts/native_install.sh."
+        )
+    if not config.exists():
+        errors.append(
+            f"Missing config file at {config}. Run ./scripts/native_install.sh to generate it."
+        )
+    if errors:
+        for msg in errors:
+            print(msg, file=sys.stderr)
+        return False
+    return True
 
 
 def main() -> int:
     args = parse_args()
     cfg = EngineConfig(katago=args.katago, model=args.model, config=args.config)
+    if not validate_environment(cfg.katago, cfg.model, cfg.config):
+        return 1
     try:
         engine = KataGoEngine(cfg)
     except (FileNotFoundError, PermissionError) as exc:


### PR DESCRIPTION
## Summary
- add native installer and launcher scripts that download the KataGo AppImage, extract the ELF, and start the HTTP server
- harden `serve.py` with environment validation and a JSON-based self-test, and refresh the README native quickstart
- add a native CI workflow that shellchecks helper scripts, stubs KataGo for `serve.py --selftest`, and address the remaining shellcheck warning

## Testing
- shellcheck scripts/*.sh
- python3 serve.py --selftest

------
https://chatgpt.com/codex/tasks/task_e_68d3aa7e2f688324b718db1eb4b6b5a4