### PR TITLE
Native bootstrap: auto-extract KataGo, fetch model, generate config; selftest + CI

### DIFF
--- a/.github/workflows/native-ci.yml
+++ b/.github/workflows/native-ci.yml
@@ -1,56 +1,39 @@
-name: native-ci
+name: Native CI
 
 on:
   push:
-    branches:
-      - 2.2
+    branches: ["**"]
   pull_request:
-    branches:
-      - 2.2
 
 jobs:
   native:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
       - name: Install shellcheck
-        run: sudo apt-get update && sudo apt-get install -y shellcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
 
       - name: Shellcheck scripts
         run: shellcheck scripts/*.sh
 
-      - name: Selftest with mock KataGo
-        run: |
-          mkdir -p .bin models config
-          cat > .bin/katago <<'STUB'
-          #!/usr/bin/env bash
-          set -euo pipefail
-          if [[ "${1:-}" == "--version" ]]; then
-            echo "KataGo mock 1.16.3"
-            exit 0
-          fi
-          if [[ "${1:-}" == "--appimage-extract" ]]; then
-            exit 0
-          fi
-          if [[ "${1:-}" == "analysis" ]]; then
-            # Consume parameters: -model <path> -config <path>
-            shift
-            shift || true
-            shift || true
-            shift || true
-            shift || true
-            while IFS= read -r line; do
-              [[ -z "$line" ]] && continue
-              echo '{"id":"ping","version":"mock","isAlive":false}'
-            done
-            exit 0
-          fi
-          echo "Unexpected invocation: $*" >&2
-          exit 1
-STUB
-          chmod +x .bin/katago
-          printf 'cfg' > config/analysis.cfg
-          printf 'model' > models/latest.bin.gz
-          python3 serve.py --selftest --katago ./.bin/katago --model ./models/latest.bin.gz --config ./config/analysis.cfg
+      - name: Bootstrap KataGo (mock engine)
+        env:
+          CI_MOCK_ENGINE: "1"
+        run: ./scripts/native_install.sh
+
+      - name: Download kata1 model
+        run: ./scripts/01_get_model.sh
+
+      - name: Run self-test
+        env:
+          CI_MOCK_ENGINE: "1"
+        run: python3 serve.py --selftest

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ port 2388.
 
 ## What's new in 2.2
 
-- Native runner: `serve.py` keeps a persistent KataGo analysis subprocess without Docker.
+- Native runner: `serve.py` keeps a persistent KataGo analysis subprocess without Docker and validates prerequisites on startup and self-test.
 - Idempotent installer: `scripts/native_install.sh` fetches v1.16.3, extracts the AppImage, and verifies the binary.
 - Systemd integration: `systemd/user/katago-json.service` and `scripts/native_enable_service.sh` manage the JSON endpoint as a
   user service.
@@ -27,7 +27,7 @@ git clone -b 2.2 https://github.com/MadManofEurope/KataGo && cd KataGo
 ./scripts/native_run.sh
 ```
 
-`native_install.sh` prepares `.bin/katago`, `config/analysis.cfg`, and supporting directories. The runner binds to `127.0.0.1:2388` by default.
+`native_install.sh` prepares `.bin/katago`, `config/analysis.cfg`, and supporting directories. `native_run.sh` will also fetch the default kata1 network on first run if `models/latest.bin.gz` is missing. The runner binds to `127.0.0.1:2388` by default.
 
 ### Health check
 
@@ -56,7 +56,7 @@ The service runs from `~/KataGo`, restarts automatically, and can be disabled wi
 
 - `config/analysis.cfg` is seeded by `scripts/native_install.sh` from `config/analysis.cfg.template`. Update it to suit your analysis
   requirements.
-- `models/latest.bin.gz` is managed by `scripts/01_get_model.sh`, which downloads the latest kata1 network and refreshes the symlink.
+- `models/latest.bin.gz` is managed by `scripts/01_get_model.sh`, which downloads a kata1 network if none exist, validates gzip integrity, and refreshes the symlink. Set `KATAGO_MODEL_URL` to override the default download URL.
 - Set `KATAGO_CONFIG` before starting the runner to override the default configuration path.
 
 ## Why extract the AppImage?

--- a/scripts/01_get_model.sh
+++ b/scripts/01_get_model.sh
@@ -4,81 +4,70 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 MODELS_DIR="${ROOT_DIR}/models"
+DEFAULT_MODEL_URL="https://media.katagotraining.org/uploaded/networks/models/kata1/kata1-b28c512nbt-s10964269312-d5332792958.bin.gz"
+MODEL_URL="${KATAGO_MODEL_URL:-${1:-${DEFAULT_MODEL_URL}}}"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd curl
+require_cmd gzip
 
 mkdir -p "${MODELS_DIR}"
 
-if ! command -v python3 >/dev/null 2>&1; then
-  echo "python3 is required to scrape kata1 network links. Install python3 and retry." >&2
-  exit 1
+find_existing_model() {
+  find "${MODELS_DIR}" -maxdepth 1 -type f -name '*.bin.gz' ! -name 'latest.bin.gz' | sort | head -n1
+}
+
+validate_model() {
+  local path="$1"
+  if [[ -z "${path}" ]]; then
+    return 1
+  fi
+  if gzip -t "${path}" >/dev/null 2>&1; then
+    echo "Using existing kata1 network: $(basename "${path}")" >&2
+    printf '%s' "${path}"
+    return 0
+  fi
+  echo "Existing model ${path} failed gzip integrity check and will be removed." >&2
+  rm -f "${path}"
+  return 1
+}
+
+download_model() {
+  local url="$1"
+  local filename="${url##*/}"
+  if [[ "${filename}" != *.bin.gz ]]; then
+    echo "Model URL must point to a .bin.gz file: ${url}" >&2
+    exit 1
+  fi
+  local dest="${MODELS_DIR}/${filename}"
+  if [[ -f "${dest}" ]]; then
+    if validate_model "${dest}" >/dev/null; then
+      printf '%s' "${dest}"
+      return 0
+    fi
+  fi
+  local tmp="${dest}.tmp"
+  echo "Downloading $(basename "${dest}")" >&2
+  curl -fL "${url}" -o "${tmp}"
+  mv "${tmp}" "${dest}"
+  if ! gzip -t "${dest}" >/dev/null 2>&1; then
+    echo "Downloaded model failed gzip integrity check: ${dest}" >&2
+    rm -f "${dest}" "${tmp}" >&2
+    exit 1
+  fi
+  printf '%s' "${dest}"
+}
+
+existing_model="$(find_existing_model)"
+if ! model_path="$(validate_model "${existing_model}")"; then
+  model_path="$(download_model "${MODEL_URL}")"
 fi
 
-if ! command -v curl >/dev/null 2>&1; then
-  echo "curl is required to download kata1 networks. Install curl and retry." >&2
-  exit 1
-fi
-
-LISTING_URL="${1:-https://katagotraining.org/networks/kata1/}"
-
-model_url="$(python3 - "$LISTING_URL" <<'PY'
-import sys
-from html.parser import HTMLParser
-from urllib.parse import urljoin
-from urllib.request import urlopen
-
-listing_url = sys.argv[1]
-
-
-class Kata1LinkParser(HTMLParser):
-    def __init__(self):
-        super().__init__()
-        self.links = []
-
-    def handle_starttag(self, tag, attrs):
-        if tag != "a":
-            return
-        href = dict(attrs).get("href")
-        if not href:
-            return
-        if href.endswith(".bin.gz") and "kata1" in href:
-            self.links.append(urljoin(listing_url, href))
-
-
-with urlopen(listing_url) as resp:
-    content = resp.read().decode("utf-8", "ignore")
-
-parser = Kata1LinkParser()
-parser.feed(content)
-
-if not parser.links:
-    raise SystemExit(f"No kata1 network links found at {listing_url}")
-
-print(parser.links[0])
-PY
-)"
-
-filename="${model_url##*/}"
-dest_path="${MODELS_DIR}/${filename}"
-
-tmp_file="${dest_path}.tmp"
-
-if [ -f "${dest_path}" ]; then
-  echo "${filename} already exists. Verifying integrity..."
-else
-  echo "Downloading ${filename} from ${model_url}" >&2
-  curl -fL "${model_url}" -o "${tmp_file}"
-  mv "${tmp_file}" "${dest_path}"
-fi
-
-# Verify gzip integrity without extracting
-if ! gzip -t "${dest_path}"; then
-  echo "Network file ${dest_path} failed gzip integrity check." >&2
-  echo "Re-download the file; incomplete downloads are not usable." >&2
-  rm -f "${dest_path}" "${tmp_file}"
-  exit 1
-fi
-
-link_tmp="${MODELS_DIR}/latest.bin.gz.tmp"
-ln -sfn "${filename}" "${link_tmp}"
-mv -Tf "${link_tmp}" "${MODELS_DIR}/latest.bin.gz"
-
-echo "Linked ${filename} as models/latest.bin.gz"
+ln -sfn "$(basename "${model_path}")" "${MODELS_DIR}/latest.bin.gz"
+echo "Linked $(basename "${model_path}") to models/latest.bin.gz" >&2

--- a/scripts/native_install.sh
+++ b/scripts/native_install.sh
@@ -7,10 +7,22 @@ MODELS_DIR="${ROOT_DIR}/models"
 CONFIG_DIR="${ROOT_DIR}/config"
 CONFIG_TEMPLATE="${CONFIG_DIR}/analysis.cfg.template"
 CONFIG_PATH="${CONFIG_DIR}/analysis.cfg"
-ZIP_URL="https://github.com/lightvector/KataGo/releases/download/v1.16.3/KataGo-v1.16.3-cuda12.5-linux-x64.zip"
-ZIP_PATH="${BIN_DIR}/KataGo-v1.16.3-cuda12.5-linux-x64.zip"
+ZIP_URL_DEFAULT="https://github.com/lightvector/KataGo/releases/download/v1.16.3/KataGo-v1.16.3-cuda12.5-linux-x64.zip"
+ZIP_URL="${KATAGO_RELEASE_URL:-${ZIP_URL_DEFAULT}}"
+ZIP_BASENAME="${ZIP_URL##*/}"
+ZIP_PATH="${BIN_DIR}/${ZIP_BASENAME}"
 APPIMAGE_PATH="${BIN_DIR}/katago"
 EXTRACTED_BIN="${BIN_DIR}/katago.bin"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd curl
+require_cmd unzip
 
 mkdir -p "${BIN_DIR}" "${MODELS_DIR}" "${CONFIG_DIR}"
 
@@ -18,42 +30,112 @@ if [[ -f "${CONFIG_TEMPLATE}" && ! -f "${CONFIG_PATH}" ]]; then
   cp "${CONFIG_TEMPLATE}" "${CONFIG_PATH}"
 fi
 
-if [[ -x "${APPIMAGE_PATH}" ]] && "${APPIMAGE_PATH}" --version >/dev/null 2>&1; then
+if [[ "${CI_MOCK_ENGINE:-0}" == "1" ]]; then
+  cat >"${APPIMAGE_PATH}" <<'PY'
+#!/usr/bin/env python3
+import json
+import sys
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    if not args:
+        print("Usage: katago [--version|analysis]", file=sys.stderr)
+        return 1
+    if args[0] == "--version":
+        print("KataGo v1.16.3-mock (CI)")
+        return 0
+    if args[0] == "analysis":
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            request_id = payload.get("id", "mock")
+            response = {
+                "id": request_id,
+                "isAlive": False,
+                "version": "v1.16.3-mock",
+            }
+            sys.stdout.write(json.dumps(response) + "\n")
+            sys.stdout.flush()
+        return 0
+    print(f"Unsupported arguments: {args}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+PY
+  chmod +x "${APPIMAGE_PATH}"
+  echo "Using CI mock KataGo engine" >&2
+  "${APPIMAGE_PATH}" --version
   exit 0
 fi
 
-echo "Installing KataGo v1.16.3 (CUDA12.5) into ${BIN_DIR}" >&2
+install_appimage() {
+  echo "Installing KataGo from ${ZIP_URL} into ${BIN_DIR}" >&2
 
-if [[ ! -f "${ZIP_PATH}" ]]; then
-  tmp_zip="${ZIP_PATH}.tmp"
-  echo "Downloading KataGo release zip..." >&2
-  curl -fL "${ZIP_URL}" -o "${tmp_zip}"
-  mv "${tmp_zip}" "${ZIP_PATH}"
+  if [[ ! -f "${ZIP_PATH}" ]]; then
+    tmp_zip="${ZIP_PATH}.tmp"
+    echo "Downloading KataGo release zip..." >&2
+    curl -fL "${ZIP_URL}" -o "${tmp_zip}"
+    mv "${tmp_zip}" "${ZIP_PATH}"
+  fi
+
+  unzip -o "${ZIP_PATH}" -d "${BIN_DIR}" >/dev/null
+
+  appimage_source="$(find "${BIN_DIR}" -maxdepth 1 -type f -name '*.AppImage' | head -n1)"
+  if [[ -z "${appimage_source}" ]]; then
+    echo "Failed to locate KataGo AppImage after unzip. Contents:" >&2
+    ls -al "${BIN_DIR}" >&2
+    exit 1
+  fi
+
+  mv -f "${appimage_source}" "${APPIMAGE_PATH}"
+  chmod +x "${APPIMAGE_PATH}"
+}
+
+extract_appimage() {
+  if [[ -L "${APPIMAGE_PATH}" ]]; then
+    return
+  fi
+  pushd "${ROOT_DIR}" >/dev/null
+  "${APPIMAGE_PATH}" --appimage-extract || true
+  if [[ -f "squashfs-root/usr/bin/katago" ]]; then
+    mv -f "squashfs-root/usr/bin/katago" "${EXTRACTED_BIN}"
+    chmod +x "${EXTRACTED_BIN}"
+    rm -rf "squashfs-root"
+    ln -sfn "katago.bin" "${APPIMAGE_PATH}"
+  fi
+  popd >/dev/null
+}
+
+if [[ ! -e "${APPIMAGE_PATH}" ]]; then
+  install_appimage
 fi
 
-unzip -o "${ZIP_PATH}" -d "${BIN_DIR}" >/dev/null
+if [[ ! -x "${APPIMAGE_PATH}" ]]; then
+  install_appimage
+fi
 
-appimage_source="$(find "${BIN_DIR}" -maxdepth 1 -type f -name '*.AppImage' | head -n1)"
-if [[ -z "${appimage_source}" ]]; then
-  echo "Failed to locate AppImage after unzip. Contents:" >&2
-  ls -al "${BIN_DIR}" >&2
+extract_appimage
+
+if [[ ! -x "${APPIMAGE_PATH}" ]]; then
+  echo "KataGo binary at ${APPIMAGE_PATH} is not executable after extraction." >&2
   exit 1
 fi
 
-mv -f "${appimage_source}" "${APPIMAGE_PATH}"
-chmod +x "${APPIMAGE_PATH}"
-
-pushd "${ROOT_DIR}" >/dev/null
-"${APPIMAGE_PATH}" --appimage-extract || true
-if [[ -f "squashfs-root/usr/bin/katago" ]]; then
-  mv -f "squashfs-root/usr/bin/katago" "${EXTRACTED_BIN}"
-  chmod +x "${EXTRACTED_BIN}"
-  rm -rf "squashfs-root"
-  ln -sfn "katago.bin" "${APPIMAGE_PATH}"
+if [[ -L "${APPIMAGE_PATH}" && ! -x "${EXTRACTED_BIN}" ]]; then
+  echo "Extraction did not produce ${EXTRACTED_BIN}." >&2
+  echo "Remove ${BIN_DIR} and rerun ./scripts/native_install.sh." >&2
+  exit 1
 fi
-popd >/dev/null
 
-if ! "${APPIMAGE_PATH}" --version >/dev/null 2>&1; then
-  echo "KataGo binary at ${APPIMAGE_PATH} failed to run. Check installation." >&2
+if ! "${APPIMAGE_PATH}" --version; then
+  echo "KataGo binary at ${APPIMAGE_PATH} failed to run. Try re-running ./scripts/native_install.sh." >&2
   exit 1
 fi

--- a/scripts/native_run.sh
+++ b/scripts/native_run.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 INSTALL_SCRIPT="${ROOT_DIR}/scripts/native_install.sh"
+MODEL_SCRIPT="${ROOT_DIR}/scripts/01_get_model.sh"
 KATAGO_BIN="${ROOT_DIR}/.bin/katago"
 MODEL_PATH="${ROOT_DIR}/models/latest.bin.gz"
 CONFIG_PATH="${KATAGO_CONFIG:-${ROOT_DIR}/config/analysis.cfg}"
@@ -11,19 +12,33 @@ PORT="2388"
 
 "${INSTALL_SCRIPT}"
 
+if [[ ! -f "${MODEL_PATH}" ]]; then
+  "${MODEL_SCRIPT}"
+fi
+
+if [[ ! -f "${CONFIG_PATH}" ]]; then
+  echo "Configuration file not found at ${CONFIG_PATH}." >&2
+  echo "Re-run ./scripts/native_install.sh or set KATAGO_CONFIG to an existing file." >&2
+  exit 1
+fi
+
 PYTHON_BIN="${PYTHON_BIN:-python3}"
 
 cleanup() {
   if [[ -n "${SERVER_PID:-}" ]] && kill -0 "${SERVER_PID}" >/dev/null 2>&1; then
-    kill "${SERVER_PID}"
-    wait "${SERVER_PID}" || true
+    kill "${SERVER_PID}" >/dev/null 2>&1 || true
+    wait "${SERVER_PID}" 2>/dev/null || true
   fi
 }
 
-trap cleanup INT TERM
-trap 'cleanup; exit' EXIT
+handle_signal() {
+  cleanup
+  exit 0
+}
 
-set +e
+trap handle_signal INT TERM
+trap cleanup EXIT
+
 "${PYTHON_BIN}" "${ROOT_DIR}/serve.py" \
   --host "${HOST}" \
   --port "${PORT}" \
@@ -31,6 +46,5 @@ set +e
   --model "${MODEL_PATH}" \
   --config "${CONFIG_PATH}" &
 SERVER_PID=$!
-set -e
 
 wait "${SERVER_PID}"

--- a/serve.py
+++ b/serve.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 
 @dataclass
@@ -193,24 +193,8 @@ def run_server(args: argparse.Namespace, engine: KataGoEngine) -> None:
         server.server_close()
 
 
-def run_selftest(engine: KataGoEngine) -> int:
-    try:
-        response_text = engine.query({"id": "ping", "action": "query_version"})
-        first_line = next((line for line in response_text.splitlines() if line.strip()), "")
-        if not first_line:
-            raise RuntimeError("KataGo returned an empty response")
-        json.loads(first_line)
-    except Exception as exc:  # noqa: BLE001
-        print(f"Selftest failed: {exc}", file=sys.stderr)
-        engine.terminate()
-        return 1
-    engine.terminate()
-    print(first_line)
-    return 0
-
-
-def validate_environment(katago: Path, model: Path, config: Path) -> bool:
-    errors: list[str] = []
+def collect_environment_errors(katago: Path, model: Path, config: Path) -> List[str]:
+    errors: List[str] = []
     if not katago.exists():
         errors.append(
             f"Missing KataGo binary at {katago}. Run ./scripts/native_install.sh to install it."
@@ -227,28 +211,60 @@ def validate_environment(katago: Path, model: Path, config: Path) -> bool:
         errors.append(
             f"Missing config file at {config}. Run ./scripts/native_install.sh to generate it."
         )
+    return errors
+
+
+def print_environment_errors(errors: List[str]) -> None:
+    for msg in errors:
+        print(msg, file=sys.stderr)
+
+
+def launch_engine(cfg: EngineConfig) -> Optional[KataGoEngine]:
+    try:
+        return KataGoEngine(cfg)
+    except (FileNotFoundError, PermissionError) as exc:
+        print(f"Failed to launch KataGo: {exc}", file=sys.stderr)
+        return None
+    except Exception as exc:  # noqa: BLE001
+        print(f"Failed to launch KataGo: {exc}", file=sys.stderr)
+        return None
+
+
+def run_selftest(cfg: EngineConfig) -> int:
+    errors = collect_environment_errors(cfg.katago, cfg.model, cfg.config)
     if errors:
-        for msg in errors:
-            print(msg, file=sys.stderr)
-        return False
-    return True
+        print_environment_errors(errors)
+        return 1
+    engine = launch_engine(cfg)
+    if engine is None:
+        return 1
+    try:
+        response_text = engine.query({"id": "ping", "action": "query_version"})
+        first_line = next((line for line in response_text.splitlines() if line.strip()), "")
+        if not first_line:
+            raise RuntimeError("KataGo returned an empty response")
+        json.loads(first_line)
+    except Exception as exc:  # noqa: BLE001
+        print(f"Selftest failed: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        engine.terminate()
+    print(first_line)
+    return 0
 
 
 def main() -> int:
     args = parse_args()
     cfg = EngineConfig(katago=args.katago, model=args.model, config=args.config)
-    if not validate_environment(cfg.katago, cfg.model, cfg.config):
-        return 1
-    try:
-        engine = KataGoEngine(cfg)
-    except (FileNotFoundError, PermissionError) as exc:
-        print(f"Failed to launch KataGo: {exc}", file=sys.stderr)
-        return 1
-    except Exception as exc:  # noqa: BLE001
-        print(f"Failed to launch KataGo: {exc}", file=sys.stderr)
+    errors = collect_environment_errors(cfg.katago, cfg.model, cfg.config)
+    if errors:
+        print_environment_errors(errors)
         return 1
     if args.selftest:
-        return run_selftest(engine)
+        return run_selftest(cfg)
+    engine = launch_engine(cfg)
+    if engine is None:
+        return 1
     run_server(args, engine)
     return 0
 


### PR DESCRIPTION
## Summary
- harden the native install script to prepare configs, extract the AppImage, and support a CI mock engine
- make the runner bootstrap models on demand and strengthen serve.py environment validation and self-test handling
- refresh the kata1 model fetcher, update documentation, and add a native CI workflow with shellcheck and self-test

## Testing
- CI_MOCK_ENGINE=1 ./scripts/native_install.sh
- ./scripts/01_get_model.sh
- CI_MOCK_ENGINE=1 python3 serve.py --selftest
- (while the mock server was running) curl -fsS http://127.0.0.1:2388/query -H 'Content-Type: application/json' -d '{"id":"ping","action":"query_version"}'


------
https://chatgpt.com/codex/tasks/task_e_68d3adcc904c8324b95d45a3415b730d