### PR TITLE
Bootstrap native runner: provision katago, model, config; selftest passes on fresh clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,10 @@ extract it once to avoid FUSE at runtime, and expose the familiar HTTP JSON API 
 
 ```bash
 git clone -b 2.3 https://github.com/MadManofEurope/KataGo && cd KataGo
-./scripts/native_install.sh
-./scripts/01_get_model.sh
-./scripts/native_run.sh
+./scripts/native_install.sh && ./scripts/01_get_model.sh && ./scripts/native_run.sh
 ```
 
-`native_install.sh` prepares `.bin/katago`, `config/analysis.cfg`, and supporting directories. `native_run.sh` bootstraps the default kata1 network on first run if `models/latest.bin.gz` is missing. The runner binds to `127.0.0.1:2388` by default.
+`native_install.sh` prepares `.bin/katago`, `config/analysis.cfg`, and supporting directories. `01_get_model.sh` downloads a kata1 network and refreshes `models/latest.bin.gz`. `native_run.sh` launches the service bound to `127.0.0.1:2388`.
 
 ### Health check
 

--- a/scripts/native_install.sh
+++ b/scripts/native_install.sh
@@ -10,8 +10,9 @@ CONFIG_PATH="${CONFIG_DIR}/analysis.cfg"
 RELEASE_TAG="v1.16.3"
 RELEASE_API_URL="https://api.github.com/repos/lightvector/KataGo/releases/tags/${RELEASE_TAG}"
 ZIP_URL_OVERRIDE="${KATAGO_RELEASE_URL:-}"
-APPIMAGE_PATH="${BIN_DIR}/katago"
-EXTRACTED_BIN="${BIN_DIR}/katago.bin"
+APPIMAGE_NAME="katago-${RELEASE_TAG}.AppImage"
+APPIMAGE_PATH="${BIN_DIR}/${APPIMAGE_NAME}"
+KATAGO_BIN="${BIN_DIR}/katago"
 
 require_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -34,7 +35,7 @@ if [[ -f "${CONFIG_TEMPLATE}" && ! -f "${CONFIG_PATH}" ]]; then
 fi
 
 if [[ "${CI_MOCK_ENGINE:-0}" == "1" ]]; then
-  cat >"${APPIMAGE_PATH}" <<'PY'
+  cat >"${KATAGO_BIN}" <<'PY'
 #!/usr/bin/env python3
 import json
 import sys
@@ -73,9 +74,9 @@ def main() -> int:
 if __name__ == "__main__":
     sys.exit(main())
 PY
-  chmod +x "${APPIMAGE_PATH}"
+  chmod +x "${KATAGO_BIN}"
   echo "Using CI mock KataGo engine" >&2
-  "${APPIMAGE_PATH}" --version
+  "${KATAGO_BIN}" --version
   exit 0
 fi
 
@@ -165,19 +166,32 @@ install_appimage() {
 }
 
 extract_appimage() {
-  if [[ -L "${APPIMAGE_PATH}" ]]; then
-    return
+  if [[ ! -x "${APPIMAGE_PATH}" ]]; then
+    echo "KataGo AppImage missing or not executable at ${APPIMAGE_PATH}." >&2
+    echo "Remove ${BIN_DIR} and rerun ./scripts/native_install.sh." >&2
+    exit 1
   fi
-  pushd "${ROOT_DIR}" >/dev/null
-  "${APPIMAGE_PATH}" --appimage-extract || true
-  if [[ -f "squashfs-root/usr/bin/katago" ]]; then
-    mv -f "squashfs-root/usr/bin/katago" "${EXTRACTED_BIN}"
-    chmod +x "${EXTRACTED_BIN}"
-    rm -rf "squashfs-root"
-    ln -sfn "katago.bin" "${APPIMAGE_PATH}"
+
+  rm -f "${KATAGO_BIN}"
+  rm -rf "${BIN_DIR}/squashfs-root"
+
+  pushd "${BIN_DIR}" >/dev/null
+  "./${APPIMAGE_NAME}" --appimage-extract >/dev/null 2>&1 || true
+  if [[ ! -f "squashfs-root/usr/bin/katago" ]]; then
+    echo "Failed to extract KataGo binary from ${APPIMAGE_PATH}." >&2
+    echo "Remove ${BIN_DIR} and rerun ./scripts/native_install.sh." >&2
+    popd >/dev/null
+    exit 1
   fi
+  mv -f "squashfs-root/usr/bin/katago" "${KATAGO_BIN}"
+  chmod +x "${KATAGO_BIN}"
+  rm -rf "squashfs-root"
   popd >/dev/null
 }
+
+if [[ -L "${KATAGO_BIN}" ]]; then
+  rm -f "${KATAGO_BIN}"
+fi
 
 if [[ ! -e "${APPIMAGE_PATH}" ]]; then
   install_appimage
@@ -189,24 +203,18 @@ fi
 
 extract_appimage
 
-if [[ ! -x "${APPIMAGE_PATH}" ]]; then
-  echo "KataGo binary at ${APPIMAGE_PATH} is not executable after extraction." >&2
+if [[ ! -x "${KATAGO_BIN}" ]]; then
+  echo "KataGo binary at ${KATAGO_BIN} is not executable after extraction." >&2
   exit 1
 fi
 
-if [[ -L "${APPIMAGE_PATH}" && ! -x "${EXTRACTED_BIN}" ]]; then
-  echo "Extraction did not produce ${EXTRACTED_BIN}." >&2
+if ! "${KATAGO_BIN}" --help >/dev/null 2>&1; then
+  echo "KataGo binary at ${KATAGO_BIN} failed to respond to --help." >&2
   echo "Remove ${BIN_DIR} and rerun ./scripts/native_install.sh." >&2
   exit 1
 fi
 
-if ! "${APPIMAGE_PATH}" --help >/dev/null 2>&1; then
-  echo "KataGo binary at ${APPIMAGE_PATH} failed to respond to --help." >&2
-  echo "Remove ${BIN_DIR} and rerun ./scripts/native_install.sh." >&2
-  exit 1
-fi
-
-if ! "${APPIMAGE_PATH}" --version; then
-  echo "KataGo binary at ${APPIMAGE_PATH} failed to run. Try re-running ./scripts/native_install.sh." >&2
+if ! "${KATAGO_BIN}" --version; then
+  echo "KataGo binary at ${KATAGO_BIN} failed to run. Try re-running ./scripts/native_install.sh." >&2
   exit 1
 fi

--- a/serve.py
+++ b/serve.py
@@ -17,6 +17,14 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 
+REPO_ROOT = Path(__file__).resolve().parent
+INSTALL_COMMAND = "./scripts/native_install.sh"
+MODEL_COMMAND = "./scripts/01_get_model.sh"
+DEFAULT_KATAGO = REPO_ROOT / ".bin/katago"
+DEFAULT_MODEL = REPO_ROOT / "models/latest.bin.gz"
+DEFAULT_CONFIG = Path(os.environ.get("KATAGO_CONFIG", REPO_ROOT / "config/analysis.cfg"))
+
+
 @dataclass
 class EngineConfig:
     katago: Path
@@ -160,17 +168,12 @@ class KataGoRequestHandler(BaseHTTPRequestHandler):
 
 
 def parse_args() -> argparse.Namespace:
-    repo_root = Path(__file__).resolve().parent
-    default_katago = repo_root / ".bin/katago"
-    default_model = repo_root / "models/latest.bin.gz"
-    default_config = Path(os.environ.get("KATAGO_CONFIG", repo_root / "config/analysis.cfg"))
-
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=2388)
-    parser.add_argument("--katago", type=Path, default=default_katago)
-    parser.add_argument("--model", type=Path, default=default_model)
-    parser.add_argument("--config", type=Path, default=default_config)
+    parser.add_argument("--katago", type=Path, default=DEFAULT_KATAGO)
+    parser.add_argument("--model", type=Path, default=DEFAULT_MODEL)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
     parser.add_argument("--selftest", action="store_true", help="Run a query_version check and exit")
     return parser.parse_args()
 
@@ -197,35 +200,39 @@ def collect_environment_errors(katago: Path, model: Path, config: Path) -> List[
     errors: List[str] = []
     if not katago.exists():
         errors.append(
-            f"Missing KataGo binary at {katago}. Run ./scripts/native_install.sh to install it."
+            f"Missing KataGo binary at {katago}. Run {INSTALL_COMMAND} to install it."
+        )
+    elif katago.is_dir():
+        errors.append(
+            f"Expected a KataGo executable at {katago}, but found a directory. Remove it and run {INSTALL_COMMAND}."
         )
     elif not os.access(katago, os.X_OK):
         errors.append(
-            f"KataGo binary at {katago} is not executable. Re-run ./scripts/native_install.sh."
+            f"KataGo binary at {katago} is not executable. Re-run {INSTALL_COMMAND}."
         )
     if not model.exists():
         errors.append(
-            f"Missing model file at {model}. Run ./scripts/01_get_model.sh after ./scripts/native_install.sh."
+            f"Missing model file at {model}. Run {MODEL_COMMAND} after {INSTALL_COMMAND}."
         )
     elif not model.is_file():
         errors.append(
-            f"KataGo model at {model} is not a regular file. Re-run ./scripts/01_get_model.sh after ./scripts/native_install.sh."
+            f"KataGo model at {model} is not a regular file. Re-run {MODEL_COMMAND} after {INSTALL_COMMAND}."
         )
     elif not os.access(model, os.R_OK):
         errors.append(
-            f"KataGo model at {model} is not readable. Fix permissions or rerun ./scripts/01_get_model.sh."
+            f"KataGo model at {model} is not readable. Fix permissions or rerun {MODEL_COMMAND}."
         )
     if not config.exists():
         errors.append(
-            f"Missing config file at {config}. Run ./scripts/native_install.sh to generate it."
+            f"Missing config file at {config}. Run {INSTALL_COMMAND} to generate it."
         )
     elif not config.is_file():
         errors.append(
-            f"Expected a config file at {config}. Run ./scripts/native_install.sh to restore it."
+            f"Expected a config file at {config}. Run {INSTALL_COMMAND} to restore it."
         )
     elif not os.access(config, os.R_OK):
         errors.append(
-            f"Config file at {config} is not readable. Fix permissions or rerun ./scripts/native_install.sh."
+            f"Config file at {config} is not readable. Fix permissions or rerun {INSTALL_COMMAND}."
         )
     return errors
 


### PR DESCRIPTION
## Summary
- extract the official KataGo AppImage into a real `.bin/katago` ELF during `native_install.sh`
- tighten `serve.py` environment validation with actionable bootstrap guidance
- document the native bootstrap chain and health check using `query_version`

## Testing
- CI_MOCK_ENGINE=1 ./scripts/native_install.sh
- CI_MOCK_MODEL=1 ./scripts/01_get_model.sh
- python3 serve.py --selftest

------
https://chatgpt.com/codex/tasks/task_e_68d3bc5407348324939b7181fa60e546