### PR TITLE
Default to KataGo AppImage and wrapper on Ubuntu 25.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # KataGo JSON Analysis Service (2.3)
 
-Native KataGo JSON analysis server for Ubuntu 25.04 "Plucky Puffin" hosts with NVIDIA GPUs. The helper scripts query the
-official KataGo v1.16.3 release, pick the best available Linux x64 CUDA AppImage (preferring CUDA 12.8, then 12.5, then 12.1),
-extract it once to avoid FUSE at runtime, and expose the familiar HTTP JSON API on port 2388.
+Native KataGo JSON analysis server for Ubuntu 25.04 "Plucky Puffin" hosts with NVIDIA GPUs. The helper scripts now download
+the upstream KataGo v1.16.3 CUDA 12.8 AppImage by default, wrap it with a stable `.bin/katago` launcher, and expose the
+familiar HTTP JSON API on port 2388.
 
 ## What's new in 2.3
 
-- Native bootstrap scripts discover the appropriate KataGo AppImage via the GitHub API, extract it once to avoid FUSE, and seed
-  `config/analysis.cfg` during installation.
+- Native bootstrap scripts prefer the upstream AppImage to avoid host `libzip` mismatches and seed `config/analysis.cfg`
+  during installation.
 - `serve.py --selftest` verifies the binary, config, and model paths before running a `query_version` probe.
 - GitHub Actions workflow exercises the bootstrap path with a mocked KataGo binary.
 
@@ -24,7 +24,11 @@ extract it once to avoid FUSE at runtime, and expose the familiar HTTP JSON API 
 git clone -b 2.3 https://github.com/MadManofEurope/KataGo && cd KataGo && ./scripts/bootstrap.sh
 ```
 
-`bootstrap.sh` verifies the checkout, installs the KataGo AppImage, downloads a kata1 network, and launches the JSON service bound to `127.0.0.1:2388`. Re-run it at any time to repair dependencies and restart the server.
+`bootstrap.sh` verifies the checkout, installs the KataGo AppImage to sidestep host `libzip` requirements, downloads a kata1 network, and launches the JSON service bound to `127.0.0.1:2388`. Re-run it at any time to repair dependencies and restart the server.
+
+### Optional: ZIP binary (advanced)
+
+The installer falls back to the CUDA 12.x ZIP release if the AppImage download fails or the host lacks a working NVIDIA GPU. The ZIP build depends on `libzip.so.4`; if the system loader reports that dependency as missing, rerun `./scripts/native_install.sh` to fetch the AppImage instead.
 
 ### Health check
 
@@ -65,6 +69,7 @@ The service runs from `~/KataGo`, restarts automatically, and can be disabled wi
 - `curl 127.0.0.1:2388/query: connection refused` → Start the server with `./scripts/bootstrap.sh` (or rerun it to restart the service).
 - `python3 serve.py --selftest` reports missing files → Rerun the script named in the message (`native_install.sh` for the binary/config or `01_get_model.sh` for the model) and run the self-test again.
 - `systemctl --user status katago-json.service: Unit katago-json.service not found.` → Enable the user service with `./scripts/native_enable_service.sh` before checking the status.
+- `error while loading shared libraries: libzip.so.4` → The ZIP binary is missing a dependency. Re-run `./scripts/native_install.sh` to download the AppImage instead.
 
 ## Configuration and models
 
@@ -73,10 +78,9 @@ The service runs from `~/KataGo`, restarts automatically, and can be disabled wi
 - `models/latest.bin.gz` is managed by `scripts/01_get_model.sh`, which downloads a kata1 network if none exist, validates gzip integrity, and refreshes the symlink. Set `KATAGO_MODEL_URL` to override the default download URL. Use `CI_MOCK_MODEL=1` to generate a tiny placeholder network for CI or test environments.
 - Set `KATAGO_CONFIG` before starting the runner to override the default configuration path.
 
-## Why extract the AppImage?
+## Why ship the AppImage?
 
-KataGo's Linux releases ship as AppImages. Extracting the AppImage at install time removes the runtime FUSE requirement, so the
-native runner works on minimal Ubuntu installations without extra kernel modules or elevated privileges.
+Ubuntu 25.04 no longer provides `libzip.so.4`, which the legacy ZIP builds require. Running the upstream AppImage keeps the CUDA 12.8 binary self-contained, bypasses host `libzip` issues, and avoids Docker entirely.
 
 ## References
 

--- a/scripts/native_install.sh
+++ b/scripts/native_install.sh
@@ -137,7 +137,8 @@ determine_zip_url() {
 }
 
 install_appimage() {
-  local arch="$(uname -m 2>/dev/null || echo unknown)"
+  local arch
+  arch="$(uname -m 2>/dev/null || echo unknown)"
   if [[ "${arch}" != "x86_64" && "${arch}" != "amd64" ]]; then
     echo "Host architecture ${arch} is not supported by the KataGo AppImage." >&2
     return 1

--- a/scripts/native_install.sh
+++ b/scripts/native_install.sh
@@ -15,6 +15,8 @@ CONFIG_PATH="${CONFIG_DIR}/analysis.cfg"
 RELEASE_TAG="v1.16.3"
 RELEASE_API_URL="https://api.github.com/repos/lightvector/KataGo/releases/tags/${RELEASE_TAG}"
 ZIP_URL_OVERRIDE="${KATAGO_RELEASE_URL:-}"
+APPIMAGE_URL="https://github.com/lightvector/KataGo/releases/download/${RELEASE_TAG}/katago-v1.16.3-cuda12.8-linux-x64.AppImage"
+APPIMAGE_PATH="${BIN_DIR}/katago.AppImage"
 KATAGO_BIN="${BIN_DIR}/katago"
 
 require_cmd() {
@@ -25,11 +27,6 @@ require_cmd() {
 }
 
 require_cmd curl
-require_cmd unzip
-
-if [[ "${CI_MOCK_ENGINE:-0}" != "1" && -z "${ZIP_URL_OVERRIDE}" ]]; then
-  require_cmd jq
-fi
 
 mkdir -p "${BIN_DIR}" "${MODELS_DIR}" "${CONFIG_DIR}" "${LOGS_DIR}"
 
@@ -89,6 +86,8 @@ determine_zip_url() {
     return 0
   fi
 
+  require_cmd jq
+
   # shellcheck disable=SC2016 # jq script uses regexes and literal $ characters.
   local jq_filter='
     [ .assets[]
@@ -137,32 +136,70 @@ determine_zip_url() {
   printf '%s' "${asset_url}"
 }
 
-install_release() {
+install_appimage() {
+  local arch="$(uname -m 2>/dev/null || echo unknown)"
+  if [[ "${arch}" != "x86_64" && "${arch}" != "amd64" ]]; then
+    echo "Host architecture ${arch} is not supported by the KataGo AppImage." >&2
+    return 1
+  fi
+
+  if ! command -v nvidia-smi >/dev/null 2>&1; then
+    echo "nvidia-smi not found; unable to confirm NVIDIA GPU presence. Skipping AppImage download." >&2
+    return 1
+  fi
+
+  if ! nvidia-smi >/dev/null 2>&1; then
+    echo "nvidia-smi command failed; skipping AppImage download." >&2
+    return 1
+  fi
+
+  echo "Installing KataGo AppImage from ${APPIMAGE_URL}" >&2
+  local tmp_path="${APPIMAGE_PATH}.tmp"
+  rm -f "${tmp_path}" "${APPIMAGE_PATH}"
+  if ! curl -fL "${APPIMAGE_URL}" -o "${tmp_path}"; then
+    echo "Failed to download KataGo AppImage." >&2
+    rm -f "${tmp_path}"
+    return 1
+  fi
+
+  mv -f "${tmp_path}" "${APPIMAGE_PATH}"
+  chmod +x "${APPIMAGE_PATH}"
+
+  cat >"${KATAGO_BIN}" <<'WRAPPER'
+#!/usr/bin/env bash
+DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+exec "$DIR/katago.AppImage" "$@"
+WRAPPER
+  chmod +x "${KATAGO_BIN}"
+
+  INSTALL_METHOD="appimage"
+  return 0
+}
+
+install_zip_release() {
+  require_cmd unzip
+
   local zip_url
   zip_url="$(determine_zip_url)"
   local zip_basename="${zip_url##*/}"
   local zip_path="${BIN_DIR}/${zip_basename}"
 
-  echo "Installing KataGo from ${zip_url} into ${BIN_DIR}" >&2
+  echo "Installing KataGo ZIP release from ${zip_url}" >&2
 
   if [[ ! -f "${zip_path}" ]]; then
     local tmp_zip="${zip_path}.tmp"
     echo "Downloading KataGo release zip..." >&2
-    curl -fL "${zip_url}" -o "${tmp_zip}"
+    if ! curl -fL "${zip_url}" -o "${tmp_zip}"; then
+      echo "Failed to download KataGo release zip." >&2
+      rm -f "${tmp_zip}"
+      exit 1
+    fi
     mv "${tmp_zip}" "${zip_path}"
   fi
 
   local unzip_dir
   unzip_dir="$(mktemp -d)"
   unzip -qo "${zip_path}" -d "${unzip_dir}"
-
-  local appimage_source
-  appimage_source="$(find "${unzip_dir}" -type f -name '*.AppImage' | head -n1)"
-  if [[ -n "${appimage_source}" ]]; then
-    install_from_appimage "${appimage_source}"
-    rm -rf "${unzip_dir}"
-    return
-  fi
 
   local binary_source
   binary_source="$(find "${unzip_dir}" -type f -name 'katago' | head -n1)"
@@ -173,79 +210,78 @@ install_release() {
     exit 1
   fi
 
-  chmod +x "${binary_source}"
-  if "${binary_source}" --appimage-help >/dev/null 2>&1; then
-    install_from_appimage "${binary_source}"
-  else
-    install_from_binary "${binary_source}"
-  fi
-  rm -rf "${unzip_dir}"
-}
-
-install_from_appimage() {
-  local appimage_source="$1"
-  local appimage_name
-  appimage_name="$(basename "${appimage_source}")"
-  local dest_name
-  if [[ "${appimage_name}" == *.AppImage ]]; then
-    dest_name="${appimage_name}"
-  else
-    dest_name="${appimage_name}.AppImage"
-  fi
-  local appimage_path="${BIN_DIR}/${dest_name}"
-
-  rm -f "${appimage_path}"
-  mv -f "${appimage_source}" "${appimage_path}"
-  chmod +x "${appimage_path}"
-
-  rm -f "${KATAGO_BIN}"
-  rm -rf "${BIN_DIR}/squashfs-root"
-
-  pushd "${BIN_DIR}" >/dev/null
-  "./${dest_name}" --appimage-extract >/dev/null 2>&1 || true
-  if [[ ! -f "squashfs-root/usr/bin/katago" ]]; then
-    echo "Failed to extract KataGo binary from ${appimage_path}." >&2
-    echo "Remove ${BIN_DIR} and rerun ./scripts/native_install.sh." >&2
-    popd >/dev/null
-    exit 1
-  fi
-  mv -f "squashfs-root/usr/bin/katago" "${KATAGO_BIN}"
-  chmod +x "${KATAGO_BIN}"
-  rm -rf "squashfs-root"
-  popd >/dev/null
-}
-
-install_from_binary() {
-  local binary_source="$1"
   local tmp_path="${KATAGO_BIN}.tmp"
-  rm -f "${tmp_path}"
-  rm -f "${KATAGO_BIN}"
+  rm -f "${tmp_path}" "${KATAGO_BIN}"
   cp "${binary_source}" "${tmp_path}"
   chmod +x "${tmp_path}"
   mv -f "${tmp_path}" "${KATAGO_BIN}"
+
+  rm -rf "${unzip_dir}"
+  rm -f "${APPIMAGE_PATH}"
+
+  INSTALL_METHOD="zip"
 }
+
+check_libzip_dependency() {
+  if [[ "${INSTALL_METHOD}" != "zip" ]]; then
+    return 0
+  fi
+
+  if ! command -v ldd >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if ldd "${KATAGO_BIN}" 2>/dev/null | grep -q 'libzip.so.4 => not found'; then
+    echo "The KataGo ZIP binary is missing libzip.so.4 on this system." >&2
+    echo "Using AppImage avoids libzip issues. Run ./scripts/native_install.sh again." >&2
+    exit 1
+  fi
+}
+
+verify_analysis_subcommand() {
+  set +e
+  local output
+  output="$("${KATAGO_BIN}" analysis -help 2>&1)"
+  local status=$?
+  set -e
+  if [[ ${status} -ne 0 ]]; then
+    if [[ "${output}" == *"libzip.so.4"* ]]; then
+      echo "Using AppImage avoids libzip issues. Run ./scripts/native_install.sh again." >&2
+    fi
+    echo "KataGo binary at ${KATAGO_BIN} could not run the analysis subcommand." >&2
+    echo "Remove ${BIN_DIR} and rerun ./scripts/native_install.sh." >&2
+    exit 1
+  fi
+}
+
+verify_version_command() {
+  if ! "${KATAGO_BIN}" version >/dev/null 2>&1; then
+    if ! "${KATAGO_BIN}" --version >/dev/null 2>&1; then
+      echo "KataGo binary at ${KATAGO_BIN} failed to report its version." >&2
+      echo "Try re-running ./scripts/native_install.sh or override KATAGO_RELEASE_URL." >&2
+      exit 1
+    fi
+  fi
+}
+
+INSTALL_METHOD=""
 
 if [[ -L "${KATAGO_BIN}" ]]; then
   rm -f "${KATAGO_BIN}"
 fi
 
-install_release
+if install_appimage; then
+  :
+else
+  echo "Falling back to the KataGo ZIP release." >&2
+  install_zip_release
+fi
 
 if [[ ! -x "${KATAGO_BIN}" ]]; then
-  echo "KataGo binary at ${KATAGO_BIN} is not executable after extraction." >&2
+  echo "KataGo binary at ${KATAGO_BIN} is not executable after installation." >&2
   exit 1
 fi
 
-if ! "${KATAGO_BIN}" analysis -help >/dev/null 2>&1; then
-  echo "KataGo binary at ${KATAGO_BIN} could not run the analysis subcommand." >&2
-  echo "Remove ${BIN_DIR} and rerun ./scripts/native_install.sh." >&2
-  exit 1
-fi
-
-if ! "${KATAGO_BIN}" version >/dev/null 2>&1; then
-  if ! "${KATAGO_BIN}" --version >/dev/null 2>&1; then
-    echo "KataGo binary at ${KATAGO_BIN} failed to report its version." >&2
-    echo "Try re-running ./scripts/native_install.sh or override KATAGO_RELEASE_URL." >&2
-    exit 1
-  fi
-fi
+check_libzip_dependency
+verify_analysis_subcommand
+verify_version_command

--- a/scripts/native_run.sh
+++ b/scripts/native_run.sh
@@ -25,6 +25,11 @@ resolve_path() {
   fi
 }
 
+echo "Preparing to start KataGo JSON server on 127.0.0.1:2388"
+echo "  KataGo binary : ${KATAGO_BIN} -> $(resolve_path "${KATAGO_BIN}")"
+echo "  Model symlink : ${MODEL_PATH} -> $(resolve_path "${MODEL_PATH}")"
+echo "  Config file   : ${CONFIG_PATH} -> $(resolve_path "${CONFIG_PATH}")"
+
 if [[ ! -x "${KATAGO_BIN}" ]]; then
   echo "Missing KataGo binary at ${KATAGO_BIN}. Run ${INSTALL_SCRIPT}" >&2
   exit 1
@@ -47,6 +52,18 @@ fi
 
 if [[ ! -r "${MODEL_PATH}" ]]; then
   echo "KataGo model at ${MODEL_PATH} is not readable." >&2
+  exit 1
+fi
+
+set +e
+analysis_output="$(${KATAGO_BIN} analysis -help 2>&1)"
+analysis_status=$?
+set -e
+if [[ ${analysis_status} -ne 0 ]]; then
+  if [[ "${analysis_output}" == *"libzip.so.4"* ]]; then
+    echo "Using AppImage avoids libzip issues. Run ./scripts/native_install.sh again." >&2
+  fi
+  echo "KataGo binary at ${KATAGO_BIN} failed the 'analysis -help' check." >&2
   exit 1
 fi
 

--- a/serve.py
+++ b/serve.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shutil
 import signal
 import subprocess
 import sys
@@ -14,7 +15,7 @@ from dataclasses import dataclass
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional, TextIO
 
 
 REPO_ROOT = Path(__file__).resolve().parent
@@ -46,6 +47,8 @@ class KataGoEngine:
     def __init__(self, cfg: EngineConfig) -> None:
         self._cfg = cfg
         self._lock = threading.Lock()
+        self._libzip_hint_emitted = False
+        self._stderr_thread: Optional[threading.Thread] = None
         self._proc = self._launch()
 
     def _launch(self) -> subprocess.Popen:
@@ -57,14 +60,41 @@ class KataGoEngine:
             "-config",
             str(self._cfg.config),
         ]
-        return subprocess.Popen(
+        proc = subprocess.Popen(
             cmd,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
-            stderr=sys.stderr,
+            stderr=subprocess.PIPE,
             text=True,
             bufsize=1,
         )
+        if proc.stderr is not None:
+            thread = threading.Thread(
+                target=self._forward_stderr,
+                args=(proc.stderr,),
+                name="katago-stderr-forward",
+                daemon=True,
+            )
+            thread.start()
+            self._stderr_thread = thread
+        return proc
+
+    def _forward_stderr(self, stream: TextIO) -> None:
+        try:
+            for line in stream:
+                sys.stderr.write(line)
+                sys.stderr.flush()
+                if "libzip.so.4" in line and not self._libzip_hint_emitted:
+                    self._libzip_hint_emitted = True
+                    sys.stderr.write(
+                        "Using AppImage avoids libzip issues. Run ./scripts/native_install.sh again.\n"
+                    )
+                    sys.stderr.flush()
+        finally:
+            try:
+                stream.close()
+            except Exception:  # noqa: BLE001 - best effort close
+                pass
 
     def terminate(self) -> None:
         proc = self._proc
@@ -76,6 +106,8 @@ class KataGoEngine:
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.wait(timeout=5)
+        if self._stderr_thread is not None:
+            self._stderr_thread.join(timeout=1)
 
     def query(self, payload: Dict[str, object]) -> str:
         text = json.dumps(payload, separators=(",", ":")) + "\n"
@@ -243,6 +275,10 @@ def collect_environment_errors(katago: Path, model: Path, config: Path) -> List[
         errors.append(
             f"KataGo binary at {katago} is not executable. Re-run {INSTALL_COMMAND}."
         )
+    else:
+        hint = detect_libzip_issue(katago)
+        if hint is not None:
+            errors.append(hint)
     if not model.exists():
         errors.append(
             f"Missing model file at {model}. Run {MODEL_COMMAND} after {INSTALL_COMMAND}."
@@ -268,6 +304,41 @@ def collect_environment_errors(katago: Path, model: Path, config: Path) -> List[
             f"Config file at {config} is not readable. Fix permissions or rerun {INSTALL_COMMAND}."
         )
     return errors
+
+
+def detect_libzip_issue(katago: Path) -> Optional[str]:
+    appimage_path = katago.parent / "katago.AppImage"
+    if appimage_path.exists():
+        return None
+    try:
+        result = subprocess.run(
+            [str(katago), "--version"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError:
+        return None
+    output = (result.stdout or "") + (result.stderr or "")
+    if "libzip.so.4" in output:
+        return "Using AppImage avoids libzip issues. Run ./scripts/native_install.sh again."
+    if shutil.which("ldd") is None:
+        return None
+    try:
+        ldd_result = subprocess.run(
+            ["ldd", str(katago)],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except OSError:
+        return None
+    combined = (ldd_result.stdout or "") + (ldd_result.stderr or "")
+    if "libzip.so.4" in combined:
+        return "Using AppImage avoids libzip issues. Run ./scripts/native_install.sh again."
+    return None
 
 
 def print_environment_errors(errors: List[str]) -> None:

--- a/systemd/user/katago-json.service
+++ b/systemd/user/katago-json.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=%h/KataGo
-ExecStart=%h/KataGo/serve.py
+ExecStart=%h/KataGo/serve.py --host 127.0.0.1 --port 2388 --katago %h/KataGo/.bin/katago --model %h/KataGo/models/latest.bin.gz --config %h/KataGo/config/analysis.cfg
 Restart=always
 
 [Install]


### PR DESCRIPTION
## Summary
- prefer the upstream CUDA 12.8 AppImage in the native installer with a wrapper and explicit libzip fallback checks
- route native_run.sh, serve.py, and the systemd unit through the wrapper while surfacing guidance when libzip is missing
- document the AppImage-first flow, optional ZIP fallback, and updated troubleshooting in the README

## Testing
- python3 -m compileall serve.py

------
https://chatgpt.com/codex/tasks/task_e_68d40f104d74832491aa52215961692f