### PR TITLE
feat: support local kata1 network selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,35 @@ curl -fsS http://127.0.0.1:2388 \
 The final `curl` command is the same request used by the container healthcheck. Successful responses include the KataGo version
 and indicate the GPU-enabled analysis service is ready.
 
-## Configuration and models
+## Configuration
 
 - `config/analysis.cfg` is mounted read-only into the container. `scripts/00_setup_dirs.sh` seeds it from
   `config/analysis.cfg.template` if the file is missing. Edit it locally to adjust analysis parameters. The container also forces
   `allowResignation=false` via `-override-config` so KataGo never resigns during analysis sessions.
 - `KATAGO_CONFIG` defaults to `/config/analysis.cfg`; override it in `.env` if you mount the config elsewhere.
-- Models in `models/` are mounted read-only. The runtime expects `/models/latest.bin.gz`; the helper script maintains this symlink so
-  you can keep multiple networks side by side.
+
+## Models
+
+- Place a local network such as `kata1-b28c512nbt-s10904468224-d5317014586.bin.gz` under `models/`, then run:
+
+  ```bash
+  ./scripts/01_get_model.sh --file ./models/kata1-b28c512nbt-s10904468224-d5317014586.bin.gz
+  ```
+
+  The script validates the `.bin.gz` file, prints its resolved path and SHA-256 checksum, and links it as `models/latest.bin.gz`.
+- Alternatively, omit `--file` (or the `MODEL_FILE` environment variable) to download the newest `kata1` network:
+
+  ```bash
+  ./scripts/01_get_model.sh
+  ```
+
+  The helper downloads the most recent network, verifies gzip integrity, and refreshes the `models/latest.bin.gz` symlink.
+
+## No host cuDNN
+
+Do **not** install `cudnn-local-repo-ubuntu2204-8.9.7.29_1.0-1_amd64.deb` or any other host-level cuDNN packages. The container
+image `nvidia/cuda:12.5.1-cudnn-runtime-ubuntu24.04` already bundles cuDNN, and the entrypoint logs a warning if `libcudnn`
+is unexpectedly missing from `ldconfig -p` output.
 
 ## Compose details
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,16 +1,30 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-MODEL="${KATAGO_MODEL:-/models/latest.bin.gz}"
-if [[ "${KATAGO_CONFIG+x}" == "x" ]]; then
-  if [[ -z "${KATAGO_CONFIG}" ]]; then
-    echo "KATAGO_CONFIG is set but empty; provide a path to a configuration file." >&2
-    exit 1
-  fi
-  CFG="${KATAGO_CONFIG}"
-else
-  CFG="/opt/katago/analysis.cfg"
+: "${KATAGO_CONFIG:=/config/analysis.cfg}"
+MODEL_LINK="/models/latest.bin.gz"
+MODEL="${KATAGO_MODEL:-${MODEL_LINK}}"
+
+if [[ -z "${KATAGO_CONFIG}" ]]; then
+  echo "KATAGO_CONFIG is set but empty; provide a path to a configuration file." >&2
+  exit 1
 fi
+
+if [[ ! -f "${KATAGO_CONFIG}" ]]; then
+  echo "Missing config: ${KATAGO_CONFIG}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${MODEL_LINK}" ]]; then
+  echo "Missing model: ${MODEL_LINK}" >&2
+  exit 1
+fi
+
+if ! ldconfig -p | grep -q libcudnn; then
+  echo "Warning: libcudnn not visible via ldconfig; proceeding because the base image includes cuDNN." >&2
+fi
+
+CFG="${KATAGO_CONFIG}"
 PORT="${PORT:-2388}"
 LISTEN_ADDR="${KATAGO_LISTEN:-0.0.0.0}"
 
@@ -47,12 +61,6 @@ if [[ -n "${KATAGO_ANALYSIS_THREADS:-}" ]]; then
   CONFIG_OVERRIDES+=("numAnalysisThreads=${KATAGO_ANALYSIS_THREADS}")
 fi
 
-if [[ ! -f "${CFG}" ]]; then
-  echo "Config not found at ${CFG}" >&2
-  ls -l "$(dirname "${CFG}")" || true
-  exit 1
-fi
-
 if [[ -z "${MODEL}" ]]; then
   echo "KATAGO_MODEL is not set." >&2
   exit 1
@@ -60,7 +68,6 @@ fi
 
 if [[ ! -f "${MODEL}" ]]; then
   echo "Model not found at ${MODEL}" >&2
-  ls -l /models || true
   exit 1
 fi
 

--- a/scripts/01_get_model.sh
+++ b/scripts/01_get_model.sh
@@ -7,19 +7,73 @@ MODELS_DIR="${ROOT_DIR}/models"
 
 mkdir -p "${MODELS_DIR}"
 
-if ! command -v python3 >/dev/null 2>&1; then
-  echo "python3 is required to scrape kata1 network links. Install python3 and retry." >&2
-  exit 1
-fi
+MODEL_FILE="${MODEL_FILE:-}"
 
-if ! command -v curl >/dev/null 2>&1; then
-  echo "curl is required to download kata1 networks. Install curl and retry." >&2
-  exit 1
-fi
+LISTING_URL="https://katagotraining.org/networks/kata1/"
 
-LISTING_URL="${1:-https://katagotraining.org/networks/kata1/}"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --file)
+      shift
+      MODEL_FILE="${1:-}"
+      if [[ -z "${MODEL_FILE}" ]]; then
+        echo "ERROR: --file requires a path argument." >&2
+        exit 1
+      fi
+      ;;
+    --help)
+      cat <<'USAGE'
+Usage: ./scripts/01_get_model.sh [--file /path/to/kata1-network.bin.gz] [listing_url]
 
-model_url="$(python3 - "$LISTING_URL" <<'PY'
+When --file or MODEL_FILE is provided, models/latest.bin.gz links to the given file.
+Otherwise the latest kata1 network is downloaded from katagotraining.org (or a custom listing URL).
+USAGE
+      exit 0
+      ;;
+    *)
+      LISTING_URL="$1"
+      ;;
+  esac
+  shift || true
+done
+
+link_latest() {
+  local source_path="$1"
+  local abs_source
+  abs_source="$(readlink -f "$source_path")"
+  if [[ -z "${abs_source}" ]]; then
+    echo "ERROR: Unable to resolve absolute path for $source_path" >&2
+    exit 1
+  fi
+  ln -sfn "${abs_source}" "${MODELS_DIR}/latest.bin.gz"
+  echo "Linked ${MODELS_DIR}/latest.bin.gz -> ${abs_source}"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${abs_source}"
+  fi
+}
+
+if [[ -n "${MODEL_FILE}" ]]; then
+  if [[ ! -f "${MODEL_FILE}" ]]; then
+    echo "ERROR: MODEL_FILE not found: ${MODEL_FILE}" >&2
+    exit 1
+  fi
+  if [[ ! "${MODEL_FILE}" =~ \.bin\.gz$ ]]; then
+    echo "ERROR: MODEL_FILE must end with .bin.gz" >&2
+    exit 1
+  fi
+  link_latest "${MODEL_FILE}"
+else
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "python3 is required to scrape kata1 network links. Install python3 and retry." >&2
+    exit 1
+  fi
+
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "curl is required to download kata1 networks. Install curl and retry." >&2
+    exit 1
+  fi
+
+  model_url="$(python3 - "$LISTING_URL" <<'PY'
 import sys
 from html.parser import HTMLParser
 from urllib.parse import urljoin
@@ -56,29 +110,33 @@ print(parser.links[0])
 PY
 )"
 
-filename="${model_url##*/}"
-dest_path="${MODELS_DIR}/${filename}"
+  filename="${model_url##*/}"
+  dest_path="${MODELS_DIR}/${filename}"
 
-tmp_file="${dest_path}.tmp"
+  tmp_file="${dest_path}.tmp"
 
-if [ -f "${dest_path}" ]; then
-  echo "${filename} already exists. Verifying integrity..."
-else
-  echo "Downloading ${filename} from ${model_url}" >&2
-  curl -fL "${model_url}" -o "${tmp_file}"
-  mv "${tmp_file}" "${dest_path}"
+  if [ -f "${dest_path}" ]; then
+    echo "${filename} already exists. Verifying integrity..."
+  else
+    echo "Downloading ${filename} from ${model_url}" >&2
+    curl -fL "${model_url}" -o "${tmp_file}"
+    mv "${tmp_file}" "${dest_path}"
+  fi
+
+  if ! gzip -t "${dest_path}"; then
+    echo "Network file ${dest_path} failed gzip integrity check." >&2
+    echo "Re-download the file; incomplete downloads are not usable." >&2
+    rm -f "${dest_path}" "${tmp_file}"
+    exit 1
+  fi
+
+  link_latest "${dest_path}"
 fi
 
-# Verify gzip integrity without extracting
-if ! gzip -t "${dest_path}"; then
-  echo "Network file ${dest_path} failed gzip integrity check." >&2
-  echo "Re-download the file; incomplete downloads are not usable." >&2
-  rm -f "${dest_path}" "${tmp_file}"
+resolved="$(readlink -f "${MODELS_DIR}/latest.bin.gz" 2>/dev/null || true)"
+if [[ -z "${resolved}" ]]; then
+  echo "ERROR: models/latest.bin.gz could not be resolved." >&2
   exit 1
 fi
 
-link_tmp="${MODELS_DIR}/latest.bin.gz.tmp"
-ln -sfn "${filename}" "${link_tmp}"
-mv -Tf "${link_tmp}" "${MODELS_DIR}/latest.bin.gz"
-
-echo "Linked ${filename} as models/latest.bin.gz"
+echo "models/latest.bin.gz now points to ${resolved}"


### PR DESCRIPTION
## Summary
- allow scripts/01_get_model.sh to accept --file or MODEL_FILE to link an existing kata1-*.bin.gz and fall back to downloading the latest network when omitted
- ensure entrypoint verifies /config/analysis.cfg and /models/latest.bin.gz before startup, warning if libcudnn is not visible
- document model workflows and the no-host-cudnn requirement in the README

## Testing
- bash -n scripts/01_get_model.sh
- bash -n entrypoint.sh

------
https://chatgpt.com/codex/tasks/task_e_68d54205019c8324aa04707edee51d6f