### PR TITLE
Make Docker CUDA image work with cuDNN AppImage extraction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.5.1-runtime-ubuntu24.04 AS downloader
+FROM nvidia/cuda:12.5.1-cudnn-runtime-ubuntu22.04 AS downloader
 
 ARG KATAGO_VER=v1.16.3
 ARG KATAGO_FLAVOR=cuda12.5-cudnn8.9.7-linux-x64
@@ -18,13 +18,13 @@ RUN set -eux; \
   unzip -j katago.zip katago; \
   rm katago.zip
 
-FROM nvidia/cuda:12.5.1-runtime-ubuntu24.04
+FROM nvidia/cuda:12.5.1-cudnn-runtime-ubuntu22.04
 
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
-    libzip4t64 \
+    libzip4 \
     python3 \
   && rm -rf /var/lib/apt/lists/*
 
@@ -32,11 +32,20 @@ RUN useradd --create-home --shell /usr/sbin/nologin katago
 
 WORKDIR /opt/katago
 
-COPY --from=downloader /tmp/katago/katago /opt/katago/katago
+COPY --from=downloader /tmp/katago/katago /opt/katago/katago.AppImage
+
+# Extract the AppImage so the runtime can execute without FUSE
+RUN set -eux; \
+  chmod +x /opt/katago/katago.AppImage; \
+  /opt/katago/katago.AppImage --appimage-extract; \
+  mv squashfs-root /opt/katago/appdir; \
+  chmod +x /opt/katago/appdir/AppRun; \
+  ln -sf /opt/katago/appdir/AppRun /opt/katago/katago; \
+  rm /opt/katago/katago.AppImage
 COPY serve.py /opt/katago/serve.py
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
-RUN chmod 755 /opt/katago/katago /opt/katago/serve.py /usr/local/bin/entrypoint.sh \
+RUN chmod 755 /opt/katago/appdir/AppRun /opt/katago/serve.py /usr/local/bin/entrypoint.sh \
   && chown -R katago:katago /opt/katago /usr/local/bin/entrypoint.sh
 
 USER katago

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# KataGo JSON Analysis Service (2.1)
+# KataGo JSON Analysis Service (2.4)
 
-Dockerized KataGo JSON analysis server tuned for Ubuntu 24.04 hosts with NVIDIA GPUs. The runtime image is based on
-`nvidia/cuda:12.5.1-runtime-ubuntu24.04`, downloads the official CUDA 12.5 build of KataGo v1.16.3, and exposes the
-JSON API on port 2388.
+Dockerized KataGo JSON analysis server tuned for NVIDIA GPUs. The runtime image is based on
+`nvidia/cuda:12.5.1-cudnn-runtime-ubuntu22.04`, downloads the official CUDA 12.5 build of KataGo v1.16.3, and exposes the
+JSON API on port 2388. The KataGo AppImage is extracted during the Docker build so the runtime container never requires
+FUSE support.
 
-## What's new in 2.1
+## What's new in 2.4
 
 - Local-first Docker Compose workflow that always builds the image from source before running.
 - Host-mounted configuration respected via `${KATAGO_CONFIG:-/config/analysis.cfg}` so local edits take effect immediately.
@@ -63,7 +64,7 @@ and indicate the GPU-enabled analysis service is ready.
 ## No host cuDNN
 
 Do **not** install `cudnn-local-repo-ubuntu2204-8.9.7.29_1.0-1_amd64.deb` or any other host-level cuDNN packages. The container
-image `nvidia/cuda:12.5.1-cudnn-runtime-ubuntu24.04` already bundles cuDNN, and the entrypoint logs a warning if `libcudnn`
+image `nvidia/cuda:12.5.1-cudnn-runtime-ubuntu22.04` already bundles cuDNN, and the entrypoint logs a warning if `libcudnn`
 is unexpectedly missing from `ldconfig -p` output.
 
 ## Compose details
@@ -74,12 +75,12 @@ container healthcheck posts `query_version` to the JSON endpoint to verify readi
 
 ## Troubleshooting
 
-- If the Docker build fails immediately at the `FROM` instruction, verify that `nvidia/cuda:12.5.1-runtime-ubuntu24.04` still
+- If the Docker build fails immediately at the `FROM` instruction, verify that `nvidia/cuda:12.5.1-cudnn-runtime-ubuntu22.04` still
   exists on Docker Hub and adjust the tag if NVIDIA republishes it under a different name.
 
 ## References
 
 - [KataGo releases](https://github.com/lightvector/KataGo/releases)
-- [CUDA 12.5.1 runtime Ubuntu 24.04 tag](https://hub.docker.com/r/nvidia/cuda/tags?name=12.5.1-runtime-ubuntu24.04)
+- [CUDA 12.5.1 cuDNN runtime Ubuntu 22.04 tag](https://hub.docker.com/r/nvidia/cuda/tags?name=12.5.1-cudnn-runtime-ubuntu22.04)
 - [Docker: Use GPUs with Compose](https://docs.docker.com/compose/gpu-support/)
 - [NVIDIA Container Toolkit install guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)

--- a/scripts/01_get_model.sh
+++ b/scripts/01_get_model.sh
@@ -45,10 +45,16 @@ link_latest() {
     echo "ERROR: Unable to resolve absolute path for $source_path" >&2
     exit 1
   fi
-  ln -sfn "${abs_source}" "${MODELS_DIR}/latest.bin.gz"
-  echo "Linked ${MODELS_DIR}/latest.bin.gz -> ${abs_source}"
+  if [[ "${abs_source}" != "${MODELS_DIR}/"* ]]; then
+    echo "ERROR: ${abs_source} must live under ${MODELS_DIR}" >&2
+    exit 1
+  fi
+  local base_name
+  base_name="$(basename "${abs_source}")"
+  ln -sfn "${base_name}" "${MODELS_DIR}/latest.bin.gz"
+  echo "models/latest.bin.gz -> ${base_name}"
   if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum "${abs_source}"
+    sha256sum "${MODELS_DIR}/${base_name}"
   fi
 }
 
@@ -61,7 +67,20 @@ if [[ -n "${MODEL_FILE}" ]]; then
     echo "ERROR: MODEL_FILE must end with .bin.gz" >&2
     exit 1
   fi
-  link_latest "${MODEL_FILE}"
+  base_name="$(basename "${MODEL_FILE}")"
+  dest_path="${MODELS_DIR}/${base_name}"
+  model_abs="$(readlink -f "${MODEL_FILE}")"
+  dest_abs="$(readlink -f "${dest_path}" 2>/dev/null || true)"
+  if [[ "${model_abs}" != "${dest_abs}" ]]; then
+    echo "Copying ${MODEL_FILE} to ${dest_path}" >&2
+    cp -f "${MODEL_FILE}" "${dest_path}"
+  fi
+  if ! gzip -t "${dest_path}"; then
+    echo "Network file ${dest_path} failed gzip integrity check." >&2
+    rm -f "${dest_path}"
+    exit 1
+  fi
+  link_latest "${dest_path}"
 else
   if ! command -v python3 >/dev/null 2>&1; then
     echo "python3 is required to scrape kata1 network links. Install python3 and retry." >&2


### PR DESCRIPTION
## Summary
- switch both Docker stages to `nvidia/cuda:12.5.1-cudnn-runtime-ubuntu22.04` and extract the KataGo AppImage during the build so runtime containers do not need FUSE
- update the model helper to copy local networks into `./models` before linking and refresh the documentation for the new cuDNN base image

## Testing
- `./scripts/01_get_model.sh --help`
- `echo 'dummy' | gzip > /tmp/sample.bin.gz && ./scripts/01_get_model.sh --file /tmp/sample.bin.gz`


------
https://chatgpt.com/codex/tasks/task_e_68d551775f148324b9d1975da0bbaa85