### PR TITLE
Upgrade image to CUDA 12.1, add stdin engine mode for KaTrain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
-FROM nvidia/cuda:12.5.1-cudnn-runtime-ubuntu22.04 AS downloader
-
-ARG KATAGO_VER=v1.16.3
-ARG KATAGO_FLAVOR=cuda12.5-cudnn8.9.7-linux-x64
+FROM nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04 AS downloader
 
 WORKDIR /tmp/katago
 
@@ -14,11 +11,11 @@ RUN apt-get update \
 
 RUN set -eux; \
   curl -fL -o katago.zip \
-    "https://github.com/lightvector/KataGo/releases/download/${KATAGO_VER}/katago-${KATAGO_VER}-${KATAGO_FLAVOR}.zip"; \
+    "https://github.com/lightvector/KataGo/releases/download/v1.16.3/katago-v1.16.3-cuda12.1-cudnn8.9.7-linux-x64.zip"; \
   unzip -j katago.zip katago; \
   rm katago.zip
 
-FROM nvidia/cuda:12.5.1-cudnn-runtime-ubuntu22.04
+FROM nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04
 
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -41,6 +38,7 @@ RUN set -eux; \
   mv squashfs-root /opt/katago/appdir; \
   chmod +x /opt/katago/appdir/AppRun; \
   ln -sf /opt/katago/appdir/AppRun /opt/katago/katago; \
+  ln -sf /opt/katago/appdir/AppRun /usr/local/bin/katago; \
   rm /opt/katago/katago.AppImage
 COPY serve.py /opt/katago/serve.py
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -1,47 +1,51 @@
-# KataGo JSON Analysis Service (2.4)
+# KataGo JSON Analysis Service (2.6)
 
 Dockerized KataGo JSON analysis server tuned for NVIDIA GPUs. The runtime image is based on
-`nvidia/cuda:12.5.1-cudnn-runtime-ubuntu22.04`, downloads the official CUDA 12.5 build of KataGo v1.16.3, and exposes the
-JSON API on port 2388. The KataGo AppImage is extracted during the Docker build so the runtime container never requires
-FUSE support.
+`nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04`, downloads the official CUDA 12.1 + cuDNN 8.9.7 build of KataGo v1.16.3, and
+exposes the JSON API on port 2388. The KataGo AppImage is extracted during the Docker build so the runtime container never
+requires FUSE support. HTTP remains the default mode, and the image now exposes KataGo's stdin/stdout JSON analysis engine for
+KaTrain and other desktop clients.
 
-## What's new in 2.4
+## What's new in 2.6
 
-- Local-first Docker Compose workflow that always builds the image from source before running.
-- Host-mounted configuration respected via `${KATAGO_CONFIG:-/config/analysis.cfg}` so local edits take effect immediately.
-- Compose GPU reservation stanza requests all NVIDIA GPUs using the standard `deploy.resources.reservations.devices` block.
-- Helper scripts are idempotent and safe to re-run; they create directories, refresh models, rebuild images, and verify the
-  JSON endpoint automatically.
+- Base image pinned to `nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04` to match the CUDA 12.1 + cuDNN 8.9.7 KataGo asset.
+- Runtime symlinks `/usr/local/bin/katago` to the AppImage launcher for both HTTP and stdin workflows.
+- `KATAGO_MODE=stdin` execs KataGo's JSON analysis engine directly; HTTP remains the default when unset.
+- Config template removes play-only keys, adds threading hints, and defaults to `numSearchThreadsPerAnalysisThread`.
+- `scripts/04_ci_smoke.sh` runs a local stdin smoke test, and `scripts/05_print_katrain_cmd.sh` prints the KaTrain override line.
+- Documentation covers the single-terminal setup flow, GPU guidance, KaTrain override, and Kivy audio freeze workaround.
 
 ## Prerequisites
 
 - [Docker](https://docs.docker.com/get-docker/)
 - [Docker Compose v2](https://docs.docker.com/compose/install/)
-- NVIDIA GPU driver compatible with CUDA 12.5 (for example, driver 550 or newer)
+- NVIDIA GPU driver compatible with CUDA 12.1 (for example, driver 530 or newer)
 - [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)
 - Enable GPU access for Compose per Docker's guidance: [Use GPUs with Docker Compose](https://docs.docker.com/compose/gpu-support/)
 
-## Quickstart
+## Single-terminal Quickstart
 
 ```bash
-cd KataGo
-./scripts/00_setup_dirs.sh            # creates config/ and models/; copies config/analysis.cfg if missing
-./scripts/01_get_model.sh              # downloads the newest kata1 network and links models/latest.bin.gz
-./scripts/02_build.sh                  # builds katago-json:${GIT_SHA_SHORT:-local}
-./scripts/03_run.sh                    # launches the JSON analysis service and waits for health
-curl -fsS http://127.0.0.1:2388 \
-  -H 'Content-Type: application/json' \
-  -d '{"id":"ping","action":"query_version"}' | python3 -m json.tool
+git clone --branch 2.6 https://github.com/MadManofEurope/KataGo.git ~/KataGo
+cd ~/KataGo
+./scripts/00_setup_dirs.sh
+./scripts/01_get_model.sh
+./scripts/02_build.sh
+./scripts/04_ci_smoke.sh katago-json:$(git rev-parse --short HEAD)
+./scripts/05_print_katrain_cmd.sh   # copy the ONE line into KaTrain -> Override engine command
 ```
 
-The final `curl` command is the same request used by the container healthcheck. Successful responses include the KataGo version
-and indicate the GPU-enabled analysis service is ready.
+> **KaTrain note:** KaTrain uses KataGo's JSON analysis engine over stdin/stdout. Use the printed one-liner; do not use the HTTP port.
+
+`scripts/04_ci_smoke.sh` uses `docker run --gpus all` with the stdin engine to verify the image, config, and model locally. The
+smoke test prints a single JSON line containing the KataGo version. `scripts/05_print_katrain_cmd.sh` outputs a ready-to-paste
+Docker command that KaTrain can run without edits.
 
 ## Configuration
 
 - `config/analysis.cfg` is mounted read-only into the container. `scripts/00_setup_dirs.sh` seeds it from
-  `config/analysis.cfg.template` if the file is missing. Edit it locally to adjust analysis parameters. The container also forces
-  `allowResignation=false` via `-override-config` so KataGo never resigns during analysis sessions.
+  `config/analysis.cfg.template` if the file is missing. Edit it locally to adjust analysis parameters. The template includes
+  tuning hints for balancing GPU batch size and thread counts.
 - `KATAGO_CONFIG` defaults to `/config/analysis.cfg`; override it in `.env` if you mount the config elsewhere.
 
 ## Models
@@ -61,26 +65,53 @@ and indicate the GPU-enabled analysis service is ready.
 
   The helper downloads the most recent network, verifies gzip integrity, and refreshes the `models/latest.bin.gz` symlink.
 
+## GPU access
+
+When running the container manually, request GPU access explicitly:
+
+```bash
+docker run --rm -i --gpus all \
+  -v "$PWD/config:/config:ro" -v "$PWD/models:/models:ro" \
+  --entrypoint /usr/local/bin/katago katago-json:local \
+  analysis -config /config/analysis.cfg -model /models/latest.bin.gz
+```
+
+The example mirrors `scripts/04_ci_smoke.sh`. For Compose deployments, use the standard device reservation stanza (Docker will
+forward the request to the NVIDIA Container Toolkit):
+
+```yaml
+services:
+  katago:
+    image: katago-json:${TAG}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    environment:
+      - KATAGO_MODE=http
+```
+
 ## No host cuDNN
 
 Do **not** install `cudnn-local-repo-ubuntu2204-8.9.7.29_1.0-1_amd64.deb` or any other host-level cuDNN packages. The container
-image `nvidia/cuda:12.5.1-cudnn-runtime-ubuntu22.04` already bundles cuDNN, and the entrypoint logs a warning if `libcudnn`
-is unexpectedly missing from `ldconfig -p` output.
-
-## Compose details
-
-`docker-compose.yml` builds the image locally (`katago-json:${GIT_SHA_SHORT:-local}`), publishes port `2388`, mounts the configuration and
-models directories read-only, and reserves all NVIDIA GPUs using the Compose `deploy.resources.reservations.devices` stanza so the
-container healthcheck posts `query_version` to the JSON endpoint to verify readiness.
+image `nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04` already bundles cuDNN, and the entrypoint logs a warning if `libcudnn` is
+unexpectedly missing from `ldconfig -p` output.
 
 ## Troubleshooting
 
-- If the Docker build fails immediately at the `FROM` instruction, verify that `nvidia/cuda:12.5.1-cudnn-runtime-ubuntu22.04` still
-  exists on Docker Hub and adjust the tag if NVIDIA republishes it under a different name.
+- If the Docker build fails immediately at the `FROM` instruction, verify that `nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04`
+  still exists on Docker Hub and adjust the tag if NVIDIA republishes it under a different name.
+- KaTrain on Python 3.13 + Kivy 2.3.1 can freeze after placing a stone if SDL2 audio is enabled. Set `KIVY_AUDIO=ffpyplayer` or
+  pin Kivy below 2.3.1. See the [Kivy environment variables reference](https://kivy.org/doc/stable/guide/environment.html) for
+  more details.
 
 ## References
 
 - [KataGo releases](https://github.com/lightvector/KataGo/releases)
-- [CUDA 12.5.1 cuDNN runtime Ubuntu 22.04 tag](https://hub.docker.com/r/nvidia/cuda/tags?name=12.5.1-cudnn-runtime-ubuntu22.04)
-- [Docker: Use GPUs with Compose](https://docs.docker.com/compose/gpu-support/)
 - [NVIDIA Container Toolkit install guide](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)
+- [Docker: Use GPUs with Compose](https://docs.docker.com/compose/gpu-support/)
+- [KaTrain](https://github.com/sanderland/katrain)
+- [Kivy environment variables](https://kivy.org/doc/stable/guide/environment.html)

--- a/config/analysis.cfg.template
+++ b/config/analysis.cfg.template
@@ -1,11 +1,14 @@
 # KataGo analysis configuration tuned for remote JSON clients.
 # scripts/00_setup_dirs.sh copies this to config/analysis.cfg if missing.
 # Adjust the parameters to match your hardware and desired latency.
+# nnMaxBatchSize = 64
+# numAnalysisThreads = 8
+# numSearchThreadsPerAnalysisThread = 8
+# Aim: (GPUs * nnMaxBatchSize) >= (numAnalysisThreads * numSearchThreadsPerAnalysisThread)
 maxVisits = 200
 numAnalysisThreads = 8
 nnMaxBatchSize = 32
-numSearchThreads = 16
+numSearchThreadsPerAnalysisThread = 8
 nnCacheSizePowerOfTwo = 20
 nnMutexPoolSizePowerOfTwo = 16
-allowSlowEngine = true
 reportAnalysisWinratesAs = "BLACK"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       PORT: "${PORT:-2388}"
       KATAGO_CONFIG: "${KATAGO_CONFIG:-/config/analysis.cfg}"
       KATAGO_MODEL: "/models/latest.bin.gz"
+      KATAGO_MODE: "http"
     ports:
       - "${PORT:-2388}:${PORT:-2388}"
     volumes:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,7 +38,7 @@ validate_positive_integer() {
   fi
 }
 
-CONFIG_OVERRIDES=("allowResignation=false")
+CONFIG_OVERRIDES=()
 
 NN_MAX_BATCH_SIZE="${KATAGO_NN_MAX_BATCH_SIZE:-32}"
 if [[ -n "${NN_MAX_BATCH_SIZE}" ]]; then
@@ -107,12 +107,19 @@ fi
 
 validate_positive_integer "PORT" "${PORT}"
 
+if [[ "${KATAGO_MODE:-http}" == "stdin" ]]; then
+  echo "Starting KataGo JSON analysis engine (stdin/stdout) with model ${REAL_MODEL} and config ${REAL_CFG}" >&2
+  exec /usr/local/bin/katago analysis \
+    -config "${REAL_CFG}" \
+    -model "${REAL_MODEL}"
+fi
+
 echo "Starting KataGo analysis @ ${LISTEN_ADDR}:${PORT} with model ${REAL_MODEL} and config ${REAL_CFG}" >&2
 
 PROXY_ARGS=(
   --listen "${LISTEN_ADDR}"
   --port "${PORT}"
-  --katago /opt/katago/katago
+  --katago /usr/local/bin/katago
   --model "${REAL_MODEL}"
   --config "${REAL_CFG}"
 )

--- a/scripts/04_ci_smoke.sh
+++ b/scripts/04_ci_smoke.sh
@@ -1,35 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
-cleanup() {
-  docker compose down -v
-}
-trap cleanup EXIT
-
-payload='{"id":"ping","action":"query_version"}'
-
-# Rebuild image without cache to ensure Dockerfile changes are respected
-docker compose build --no-cache
-
-docker compose up -d
-
-endpoint="http://127.0.0.1:2388"
-start_time=$(date +%s)
-
-while true; do
-  if curl -fsS "${endpoint}" \
-    -H 'Content-Type: application/json' \
-    -d "${payload}" >/dev/null; then
-    break
-  fi
-
-  if (( $(date +%s) - start_time >= 60 )); then
-    echo "KataGo JSON API did not become ready within 60 seconds" >&2
-    docker compose logs --no-color katago | tail -n 200
-    exit 1
-  fi
-
-  sleep 2
-done
-
-echo "KataGo JSON API responded successfully"
+IMG="${1:-katago-json:local}"
+printf '%s\n' '{"id":"ping","action":"query_version"}' | \
+  docker run --rm -i --gpus all \
+    -v "$PWD/config:/config:ro" -v "$PWD/models:/models:ro" \
+    --entrypoint /usr/local/bin/katago "$IMG" \
+    analysis -config /config/analysis.cfg -model /models/latest.bin.gz | head -n1

--- a/scripts/05_print_katrain_cmd.sh
+++ b/scripts/05_print_katrain_cmd.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 TAG="$(git rev-parse --short HEAD 2>/dev/null || echo local)"
-echo "/usr/bin/docker run --rm -i --gpus all -v \"$HOME/KataGo/config:/config:ro\" -v \"$HOME/KataGo/models:/models:ro\" --entrypoint /usr/local/bin/katago katago-json:${TAG} analysis -config /config/analysis.cfg -model /models/latest.bin.gz"
+printf '%s\n' \
+  "/usr/bin/docker run --rm -i --gpus all -v \"$HOME/KataGo/config:/config:ro\" -v \"$HOME/KataGo/models:/models:ro\" --entrypoint /usr/local/bin/katago katago-json:${TAG} analysis -config /config/analysis.cfg -model /models/latest.bin.gz"

--- a/scripts/05_print_katrain_cmd.sh
+++ b/scripts/05_print_katrain_cmd.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+TAG="$(git rev-parse --short HEAD 2>/dev/null || echo local)"
+echo "/usr/bin/docker run --rm -i --gpus all -v \"$HOME/KataGo/config:/config:ro\" -v \"$HOME/KataGo/models:/models:ro\" --entrypoint /usr/local/bin/katago katago-json:${TAG} analysis -config /config/analysis.cfg -model /models/latest.bin.gz"


### PR DESCRIPTION
## Summary
- pin the Docker base image to CUDA 12.1.1 + cuDNN 8 and download the matching KataGo v1.16.3 build
- expose KataGo's stdin/stdout JSON analysis engine via KATAGO_MODE while keeping HTTP as default
- clean up the analysis config template, add KaTrain-friendly tooling, and refresh README guidance

## Testing
- `bash -n scripts/04_ci_smoke.sh scripts/05_print_katrain_cmd.sh entrypoint.sh`
- `./scripts/05_print_katrain_cmd.sh`
- `./scripts/04_ci_smoke.sh katago-json:local` *(fails: docker: command not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d59ddd29e883248e03b09c8edb30a2